### PR TITLE
[formatter] fish_indent

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ To view configured and available formatters, as well as to see the path to the l
 - [elm_format](https://github.com/avh4/elm-format) - elm-format formats Elm source code according to a standard set of rules based on the official [Elm Style Guide](https://elm-lang.org/docs/style-guide).
 - [erb_format](https://github.com/nebulab/erb-formatter) - Format ERB files with speed and precision.
 - [eslint_d](https://github.com/mantoni/eslint_d.js/) - Like ESLint, but faster.
+- [fish_indent](https://fishshell.com/docs/current/cmds/fish_indent.html) - Indent or otherwise prettify a piece of fish code.
 - [gdformat](https://github.com/Scony/godot-gdscript-toolkit) - A formatter for Godot's gdscript.
 - [gofmt](https://pkg.go.dev/cmd/gofmt) - Formats go programs.
 - [gofumpt](https://github.com/mvdan/gofumpt) - Enforce a stricter format than gofmt, while being backwards compatible. That is, gofumpt is happy with a subset of the formats that gofmt is happy with.

--- a/lua/conform/formatters/fish_indent.lua
+++ b/lua/conform/formatters/fish_indent.lua
@@ -1,0 +1,8 @@
+---@type conform.FormatterConfig
+return {
+  meta = {
+    url = "https://fishshell.com/docs/current/cmds/fish_indent.html",
+    description = "Indent or otherwise prettify a piece of fish code.",
+  },
+  command = "fish_indent",
+}


### PR DESCRIPTION
This PR adds fish_indent from [null-ls](https://github.com/jose-elias-alvarez/null-ls.nvim/blob/main/lua/null-ls/builtins/formatting/fish_indent.lua).