### PR TITLE
feat: notify when formatter errors, and add notify_on_error config option

### DIFF
--- a/lua/conform/init.lua
+++ b/lua/conform/init.lua
@@ -50,6 +50,8 @@ M.formatters_by_ft = {}
 ---@type table<string, conform.FormatterConfig|fun(bufnr: integer): nil|conform.FormatterConfig>
 M.formatters = {}
 
+M.notify_on_error = true
+
 M.setup = function(opts)
   opts = opts or {}
 
@@ -58,6 +60,9 @@ M.setup = function(opts)
 
   if opts.log_level then
     require("conform.log").level = opts.log_level
+  end
+  if opts.notify_on_error ~= nil then
+    M.notify_on_error = opts.notify_on_error
   end
 
   for ft, formatters in pairs(M.formatters_by_ft) do
@@ -272,7 +277,7 @@ M.format = function(opts)
     end
 
     if opts.async then
-      require("conform.runner").format_async(opts.bufnr, formatters, opts.range)
+      require("conform.runner").format_async(opts.bufnr, formatters, opts.quiet, opts.range)
     else
       require("conform.runner").format_sync(
         opts.bufnr,

--- a/lua/conform/util.lua
+++ b/lua/conform/util.lua
@@ -91,4 +91,14 @@ M.tbl_slice = function(tbl, start_idx, end_idx)
   return ret
 end
 
+---@param cb fun(...)
+---@param wrapper fun(...)
+---@return fun(...)
+M.wrap_callback = function(cb, wrapper)
+  return function(...)
+    wrapper(...)
+    cb(...)
+  end
+end
+
 return M

--- a/tests/options_doc.lua
+++ b/tests/options_doc.lua
@@ -22,6 +22,8 @@ require("conform").setup({
   },
   -- Set the log level. Use `:ConformInfo` to see the location of the log file.
   log_level = vim.log.levels.ERROR,
+  -- Conform will notify you when a formatter errors
+  notify_on_error = true,
   -- Define custom formatters here
   formatters = {
     my_formatter = {


### PR DESCRIPTION
For #9 

Now by default if a format command errors, we will notify the user. Successive failures will not notify until there is at least one success. This can be disabled by either setting `notify_on_error = false` in the setup options, or by passing `quiet = true` to `conform.format()`.