### PR TITLE
fix readme error and add a tip

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ require("conform").setup({
     formatters_by_ft = {
         lua = { "stylua" },
         -- Conform will use the first available formatter in the list
-        javascript = { "prettierd", "prettier" },
+        javascript = { "prettier_d", "prettier" },
         -- Formatters can also be specified with additional options
         python = {
             formatters = { "isort", "black" },
@@ -146,17 +146,6 @@ require("conform").setup({
 See [conform.format()](#formatopts-callback) for more details about the parameters.
 
 To view configured and available formatters, as well as to see the path to the log file, run `:ConformInfo`
-
-To see all preset configurations, you can see [here](https://github.com/stevearc/conform.nvim/tree/master/lua/conform/formatters), you just need add filename to your config for `conform`, like this:
-
-```lua
--- for prettier_d
-require("conform").setup({
-    formatters_by_ft = {
-        javascript = { "prettierd"},
-    },
-})
-```
 
 ## Formatters
 
@@ -220,7 +209,7 @@ require("conform").setup({
   formatters_by_ft = {
     lua = { "stylua" },
     -- Conform will use the first available formatter in the list
-    javascript = { "prettierd", "prettier" },
+    javascript = { "prettier_d", "prettier" },
     -- Formatters can also be specified with additional options
     python = {
       formatters = { "isort", "black" },

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ require("conform").setup({
     formatters_by_ft = {
         lua = { "stylua" },
         -- Conform will use the first available formatter in the list
-        javascript = { "prettier_d", "prettier" },
+        javascript = { "prettierd", "prettier" },
         -- Formatters can also be specified with additional options
         python = {
             formatters = { "isort", "black" },
@@ -146,6 +146,17 @@ require("conform").setup({
 See [conform.format()](#formatopts-callback) for more details about the parameters.
 
 To view configured and available formatters, as well as to see the path to the log file, run `:ConformInfo`
+
+To see all preset configurations, you can see [here](https://github.com/stevearc/conform.nvim/tree/master/lua/conform/formatters), you just need add filename to your config for `conform`, like this:
+
+```lua
+-- for prettier_d
+require("conform").setup({
+    formatters_by_ft = {
+        javascript = { "prettierd"},
+    },
+})
+```
 
 ## Formatters
 
@@ -209,7 +220,7 @@ require("conform").setup({
   formatters_by_ft = {
     lua = { "stylua" },
     -- Conform will use the first available formatter in the list
-    javascript = { "prettier_d", "prettier" },
+    javascript = { "prettierd", "prettier" },
     -- Formatters can also be specified with additional options
     python = {
       formatters = { "isort", "black" },

--- a/scripts/options_doc.lua
+++ b/scripts/options_doc.lua
@@ -3,7 +3,7 @@ require("conform").setup({
   formatters_by_ft = {
     lua = { "stylua" },
     -- Conform will use the first available formatter in the list
-    javascript = { "prettier_d", "prettier" },
+    javascript = { "prettierd", "prettier" },
     -- Formatters can also be specified with additional options
     python = {
       formatters = { "isort", "black" },


### PR DESCRIPTION
 fix config error, and add a tip for formatters list

Oh, it is `prettierd`, not `prettier_d`, it gives is that "No config found". At first I thought it was because the configuration of pretter was not given.

Then I started to troubleshoot my configuration file, and finally I found out that the sample configuration in the readme was wrong 🥹