### PR TITLE
feat: add GNU/BSD indent

### DIFF
--- a/lua/conform/formatters/indent.lua
+++ b/lua/conform/formatters/indent.lua
@@ -1,0 +1,9 @@
+---@type conform.FileFormatterConfig
+return {
+  meta = {
+    url = "https://www.gnu.org/software/indent/",
+    description = "GNU Indent",
+  },
+  command = "indent",
+  stdin = true,
+}


### PR DESCRIPTION
Hi,

Wonderful plugin! Thank you. This PR adds `indent` which is a C formatter.

On a typical GNU/Linux system there's a good chance GNU Indent is preinstalled and if you're on a BSD system (such as OpenBSD) there's the BSD version of the `indent` program.

Edit: I wasn't sure if the meta data could be omitted so I added the GNU information (since it's the most common and widely available).