### PR TITLE
feat: make lsp_fallback behavior more intuitive

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Lightweight yet powerful formatter plugin for Neovim
   - [list_formatters(bufnr)](#list_formattersbufnr)
   - [list_all_formatters()](#list_all_formatters)
   - [get_formatter_info(formatter, bufnr)](#get_formatter_infoformatter-bufnr)
+  - [will_fallback_lsp(options)](#will_fallback_lspoptions)
 - [Acknowledgements](#acknowledgements)
 
 <!-- /TOC -->
@@ -241,12 +242,9 @@ require("conform").setup({
     -- Use a sub-list to run only the first available formatter
     javascript = { { "prettierd", "prettier" } },
     -- Use the "*" filetype to run formatters on all filetypes.
-    -- Note that if you use this, you may want to set lsp_fallback = "always"
-    -- (see :help conform.format)
     ["*"] = { "codespell" },
-    -- Use the "_" filetype to run formatters on all filetypes
-    -- that don't have other formatters configured. Again, you may want to
-    -- set lsp_fallback = "always" when using this value.
+    -- Use the "_" filetype to run formatters on filetypes that don't
+    -- have other formatters configured.
     ["_"] = { "trim_whitespace" },
   },
   -- If this is set, Conform will run the formatter on save.
@@ -384,6 +382,15 @@ Get information about a formatter (including availability)
 | --------- | -------------- | ------------------------- |
 | formatter | `string`       | The name of the formatter |
 | bufnr     | `nil\|integer` |                           |
+
+### will_fallback_lsp(options)
+
+`will_fallback_lsp(options): boolean` \
+Check if the buffer will use LSP formatting when lsp_fallback = true
+
+| Param   | Type         | Desc                                 |
+| ------- | ------------ | ------------------------------------ |
+| options | `nil\|table` | Options passed to vim.lsp.buf.format |
 <!-- /API -->
 
 ## Acknowledgements

--- a/doc/conform.txt
+++ b/doc/conform.txt
@@ -21,12 +21,9 @@ OPTIONS                                                          *conform-option
         -- Use a sub-list to run only the first available formatter
         javascript = { { "prettierd", "prettier" } },
         -- Use the "*" filetype to run formatters on all filetypes.
-        -- Note that if you use this, you may want to set lsp_fallback = "always"
-        -- (see :help conform.format)
         ["*"] = { "codespell" },
-        -- Use the "_" filetype to run formatters on all filetypes
-        -- that don't have other formatters configured. Again, you may want to
-        -- set lsp_fallback = "always" when using this value.
+        -- Use the "_" filetype to run formatters on filetypes that don't
+        -- have other formatters configured.
         ["_"] = { "trim_whitespace" },
       },
       -- If this is set, Conform will run the formatter on save.
@@ -148,6 +145,12 @@ get_formatter_info({formatter}, {bufnr}): conform.FormatterInfo *conform.get_for
     Parameters:
       {formatter} `string` The name of the formatter
       {bufnr}     `nil|integer`
+
+will_fallback_lsp({options}): boolean                  *conform.will_fallback_lsp*
+    Check if the buffer will use LSP formatting when lsp_fallback = true
+
+    Parameters:
+      {options} `nil|table` Options passed to |vim.lsp.buf.format|
 
 --------------------------------------------------------------------------------
 FORMATTERS                                                    *conform-formatters*

--- a/scripts/options_doc.lua
+++ b/scripts/options_doc.lua
@@ -7,12 +7,9 @@ require("conform").setup({
     -- Use a sub-list to run only the first available formatter
     javascript = { { "prettierd", "prettier" } },
     -- Use the "*" filetype to run formatters on all filetypes.
-    -- Note that if you use this, you may want to set lsp_fallback = "always"
-    -- (see :help conform.format)
     ["*"] = { "codespell" },
-    -- Use the "_" filetype to run formatters on all filetypes
-    -- that don't have other formatters configured. Again, you may want to
-    -- set lsp_fallback = "always" when using this value.
+    -- Use the "_" filetype to run formatters on filetypes that don't
+    -- have other formatters configured.
     ["_"] = { "trim_whitespace" },
   },
   -- If this is set, Conform will run the formatter on save.


### PR DESCRIPTION
Following up on #31, #33

I wasn't completely happy with the earlier solution. If you want to run `{ "trim_whitespace" }` on all filetypes but still use LSP formatting, you would have to pass `lsp_fallback = "always"`. But if you _didn't_ want LSP formatting on filetypes where you have formatters configured, you would have to write a helper function to do some detection of the filetype and determine if you want to pass in `true` or `"always"` (#36). I think that the _common case_ for formatting is:

- Configure specific formatters to use for some filetypes, don't use LSP
- For non-configured filetypes, default to using LSP formatting
- If no LSP formatting is available, maybe use some generic formatters (e.g. `trim_whitespace`)

I would like to optimize for this common case. This PR makes it so that if you pass `lsp_fallback = true`, conform will prefer the LSP formatter over formatters configured with the `"*"` or `"_"` filetypes.

There are still some scenarios that will require helper functions or explicitly passing formatters, but hopefully fewer.