### PR TITLE
Change buf format URL

### DIFF
--- a/lua/conform/formatters/buf.lua
+++ b/lua/conform/formatters/buf.lua
@@ -1,7 +1,7 @@
 ---@type conform.FileFormatterConfig
 return {
   meta = {
-    url = "https://buf.build/docs/lint/overview",
+    url = "https://buf.build/docs/reference/cli/buf/format",
     description = "A new way of working with Protocol Buffers",
   },
   command = "buf",


### PR DESCRIPTION
Noticed this was pointing to the `buf lint` docs - seemed like the `buf format` CLI reference might be better. An alternative might be the `buf format` [style reference](https://buf.build/docs/format/style), but that doesn't seem as good.