### PR TITLE
feat(php-cs-fixer): Add support for php-cs-fixer

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,7 @@ To view configured and available formatters, as well as to see the log file, run
 - [perlimports](https://github.com/perl-ide/App-perlimports) - Make implicit Perl imports explicit
 - [perltidy](https://github.com/perltidy/perltidy) - Perl::Tidy, a source code formatter for Perl
 - [pg_format](https://github.com/darold/pgFormatter) - PostgreSQL SQL syntax beautifier.
+- [php_cs_fixer](https://github.com/PHP-CS-Fixer/PHP-CS-Fixer) - The PHP Coding Standards Fixer.
 - [prettier](https://github.com/prettier/prettier) - Prettier is an opinionated code formatter. It enforces a consistent style by parsing your code and re-printing it with its own rules that take the maximum line length into account, wrapping code when necessary.
 - [prettierd](https://github.com/fsouza/prettierd) - prettier, as a daemon, for ludicrous formatting speed.
 - [rubocop](https://github.com/rubocop/rubocop) - Ruby static code analyzer and formatter, based on the community Ruby style guide.

--- a/lua/conform/formatters/php_cs_fixer.lua
+++ b/lua/conform/formatters/php_cs_fixer.lua
@@ -6,7 +6,7 @@ return {
     url = "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer",
     description = "The PHP Coding Standards Fixer.",
   },
-  command = util.path_or({
+  command = util.find_executable({
     "tools/php-cs-fixer/vendor/bin/php-cs-fixer",
     "vendor/bin/php-cs-fixer",
   }, "php-cs-fixer"),

--- a/lua/conform/formatters/php_cs_fixer.lua
+++ b/lua/conform/formatters/php_cs_fixer.lua
@@ -1,0 +1,15 @@
+local util = require("conform.util")
+
+---@type conform.FileFormatterConfig
+return {
+  meta = {
+    url = "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer",
+    description = "The PHP Coding Standards Fixer.",
+  },
+  command = util.path_or({
+    "tools/php-cs-fixer/vendor/bin/php-cs-fixer",
+    "vendor/bin/php-cs-fixer",
+  }, "php-cs-fixer"),
+  args = { "fix", "$FILENAME" },
+  stdin = false,
+}


### PR DESCRIPTION
- Added a simple utility to check a list of paths and return the first that exists, or a default. Useful for defining commands for a formatter so it will call the correct executable.
- Added support for `php-cs-fixer`.