### PR TITLE
fix(golines): Pass $FILENAME to golines

### DIFF
--- a/lua/conform/formatters/golines.lua
+++ b/lua/conform/formatters/golines.lua
@@ -5,4 +5,5 @@ return {
     description = "A golang formatter that fixes long lines",
   },
   command = "golines",
+  args = { "$FILENAME" },
 }


### PR DESCRIPTION
`golines` with no arguments tries to format the entire project which takes too long and times out.