### PR TITLE
feat: add darker

### DIFF
--- a/lua/conform/formatters/darker.lua
+++ b/lua/conform/formatters/darker.lua
@@ -6,7 +6,15 @@ return {
     description = "Run black only on changed lines.",
   },
   command = "darker",
-  args = { "--stdout", "--quiet", "$FILENAME" },
+  args = {
+    "--quiet",
+    "--no-color",
+    "--stdout",
+    "--revision",
+    "HEAD..:STDIN:",
+    "--stdin-filename",
+    "$FILENAME",
+  },
   cwd = util.root_file({
     -- https://github.com/akaihola/darker#customizing-darker-black-isort-flynt-and-linter-behavior
     "pyproject.toml",

--- a/lua/conform/formatters/darker.lua
+++ b/lua/conform/formatters/darker.lua
@@ -1,0 +1,14 @@
+local util = require("conform.util")
+---@type conform.FileFormatterConfig
+return {
+  meta = {
+    url = "https://github.com/akaihola/darker",
+    description = "Run black only on changed lines.",
+  },
+  command = "darker",
+  args = { "--stdout", "--quiet", "$FILENAME" },
+  cwd = util.root_file({
+    -- https://github.com/akaihola/darker#customizing-darker-black-isort-flynt-and-linter-behavior
+    "pyproject.toml",
+  }),
+}

--- a/lua/conform/formatters/darker.lua
+++ b/lua/conform/formatters/darker.lua
@@ -6,15 +6,28 @@ return {
     description = "Run black only on changed lines.",
   },
   command = "darker",
-  args = {
-    "--quiet",
-    "--no-color",
-    "--stdout",
-    "--revision",
-    "HEAD..:STDIN:",
-    "--stdin-filename",
-    "$FILENAME",
-  },
+  args = function(ctx)
+    -- make sure pre-save doesn't lose changes while post-save respects
+    -- the revision setting potentially set in pyproject.toml
+    if vim.bo[ctx.buf].modified then
+      return {
+        "--quiet",
+        "--no-color",
+        "--stdout",
+        "--revision",
+        "HEAD..:STDIN:",
+        "--stdin-filename",
+        "$FILENAME",
+      }
+    else
+      return {
+        "--quiet",
+        "--no-color",
+        "--stdout",
+        "$FILENAME",
+      }
+    end
+  end,
   cwd = util.root_file({
     -- https://github.com/akaihola/darker#customizing-darker-black-isort-flynt-and-linter-behavior
     "pyproject.toml",


### PR DESCRIPTION
[`darker`](https://github.com/akaihola/darker) runs [`black`](https://github.com/psf/black) only on the changed lines in a git repo. Useful in situations where the whole repo hasn't been painted black for one reason or another but you still want to be able to run autoformatter on changes you made.