### PR TITLE
feat: format injected languages

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Lightweight yet powerful formatter plugin for Neovim
 - **Fixes bad-behaving LSP formatters** - Some LSP servers are lazy and simply replace the entire buffer, leading to the problems mentioned above. Conform hooks into the LSP handler and turns these responses into proper piecewise changes.
 - **Enables range formatting for all formatters** - Since conform calculates minimal diffs, it can perform range formatting even if the underlying formatter doesn't support it.
 - **Simple API** - Conform exposes a simple, imperative API modeled after `vim.lsp.buf.format()`.
+- **Formats embedded code blocks** - Use the `injected` formatter to format code blocks e.g. in markdown files.
 
 ## Installation
 
@@ -192,6 +193,7 @@ To view configured and available formatters, as well as to see the log file, run
 - [golines](https://github.com/segmentio/golines) - A golang formatter that fixes long lines
 - [htmlbeautifier](https://github.com/threedaymonk/htmlbeautifier) - A normaliser/beautifier for HTML that also understands embedded Ruby. Ideal for tidying up Rails templates.
 - [indent](https://www.gnu.org/software/indent/) - GNU Indent
+- [injected](lua/conform/formatters/injected.lua) - Format treesitter injected languages.
 - [isort](https://github.com/PyCQA/isort) - Python utility / library to sort imports alphabetically and automatically separate them into sections and by type.
 - [jq](https://github.com/stedolan/jq) - Command-line JSON processor.
 - [latexindent](https://github.com/cmhughes/latexindent.pl) - A perl script for formatting LaTeX files that is generally included in major TeX distributions.

--- a/doc/conform.txt
+++ b/doc/conform.txt
@@ -196,6 +196,7 @@ FORMATTERS                                                    *conform-formatter
 `htmlbeautifier` - A normaliser/beautifier for HTML that also understands
                  embedded Ruby. Ideal for tidying up Rails templates.
 `indent` - GNU Indent
+`injected` - Format treesitter injected languages.
 `isort` - Python utility / library to sort imports alphabetically and
         automatically separate them into sections and by type.
 `jq` - Command-line JSON processor.

--- a/doc/recipes.md
+++ b/doc/recipes.md
@@ -41,11 +41,12 @@ require("conform.formatters.yamlfix").env = {
 }
 
 -- Or create your own formatter that overrides certain values
-require("conform").formatters.yamlfix = vim.tbl_deep_extend("force", require("conform.formatters.yamlfix"), {
-  env = {
-    YAMLFIX_SEQUENCE_STYLE = "block_style",
-  },
-})
+require("conform").formatters.yamlfix =
+  vim.tbl_deep_extend("force", require("conform.formatters.yamlfix"), {
+    env = {
+      YAMLFIX_SEQUENCE_STYLE = "block_style",
+    },
+  })
 
 -- Here is an example that modifies the command arguments for prettier to add
 -- a custom config file, if it is present
@@ -188,8 +189,8 @@ require("conform").formatters.prettier = vim.tbl_deep_extend("force", prettier, 
 
 -- Pass append=true to append the extra arguments to the end
 local deno_fmt = require("conform.formatters.deno_fmt")
-require("conform").formatters.deno_fmt = vim.tbl_deep_extend('force', deno_fmt, {
-  args = util.extend_args(deno_fmt.args, { "--use-tabs" }, { append = true })
+require("conform").formatters.deno_fmt = vim.tbl_deep_extend("force", deno_fmt, {
+  args = util.extend_args(deno_fmt.args, { "--use-tabs" }, { append = true }),
 })
 
 -- There is also a utility to modify a formatter in-place

--- a/lua/conform/formatters/injected.lua
+++ b/lua/conform/formatters/injected.lua
@@ -1,0 +1,98 @@
+---@param range? conform.Range
+---@param start_lnum integer
+---@param end_lnum integer
+---@return boolean
+local function in_range(range, start_lnum, end_lnum)
+  return not range or (start_lnum <= range["end"][1] and range["start"][1] <= end_lnum)
+end
+
+---@type conform.FileLuaFormatterConfig
+return {
+  meta = {
+    url = "lua/conform/formatters/injected.lua",
+    description = "Format treesitter injected languages.",
+  },
+  condition = function(ctx)
+    local ok = pcall(vim.treesitter.get_parser, ctx.buf)
+    return ok
+  end,
+  format = function(ctx, lines, callback)
+    local conform = require("conform")
+    local util = require("conform.util")
+    local ok, parser = pcall(vim.treesitter.get_parser, ctx.buf)
+    if not ok then
+      callback("No treesitter parser for buffer")
+      return
+    end
+    local root_lang = parser:lang()
+    local regions = {}
+    for lang, child_lang in pairs(parser:children()) do
+      local formatter_names = conform.formatters_by_ft[lang]
+      if formatter_names and lang ~= root_lang then
+        for _, tree in ipairs(child_lang:trees()) do
+          local root = tree:root()
+          local start_lnum = root:start() + 1
+          local end_lnum = root:end_()
+          if start_lnum <= end_lnum and in_range(ctx.range, start_lnum, end_lnum) then
+            table.insert(regions, { lang, start_lnum, end_lnum })
+          end
+        end
+      end
+    end
+    -- Sort from largest start_lnum to smallest
+    table.sort(regions, function(a, b)
+      return a[2] > b[2]
+    end)
+
+    local replacements = {}
+    local format_error = nil
+
+    local function apply_format_results()
+      if format_error then
+        callback(format_error)
+        return
+      end
+
+      local formatted_lines = vim.deepcopy(lines)
+      for _, replacement in ipairs(replacements) do
+        local start_lnum, end_lnum, new_lines = unpack(replacement)
+        for _ = start_lnum, end_lnum do
+          table.remove(formatted_lines, start_lnum)
+        end
+        for i = #new_lines, 1, -1 do
+          table.insert(formatted_lines, start_lnum, new_lines[i])
+        end
+      end
+      callback(nil, formatted_lines)
+    end
+
+    local num_format = 0
+    local formatter_cb = function(err, idx, start_lnum, end_lnum, new_lines)
+      if err then
+        format_error = err
+      else
+        replacements[idx] = { start_lnum, end_lnum, new_lines }
+      end
+      num_format = num_format - 1
+      if num_format == 0 then
+        apply_format_results()
+      end
+    end
+    local last_start_lnum = #lines + 1
+    for _, region in ipairs(regions) do
+      local lang, start_lnum, end_lnum = unpack(region)
+      -- Ignore regions that overlap (contain) other regions
+      if end_lnum < last_start_lnum then
+        num_format = num_format + 1
+        last_start_lnum = start_lnum
+        local input_lines = util.tbl_slice(lines, start_lnum, end_lnum)
+        local formatter_names = conform.formatters_by_ft[lang]
+        local format_opts = { async = true, bufnr = ctx.buf, quiet = true }
+        local idx = num_format
+        conform.format_lines(formatter_names, input_lines, format_opts, function(err, new_lines)
+          formatter_cb(err, idx, start_lnum, end_lnum, new_lines)
+        end)
+      end
+    end
+  end,
+}


### PR DESCRIPTION
New `injected` formatter that will find injected languages using treesitter and format those code snippets with the configured formatters. To use:

```lua
require("conform").setup({
  formatters_by_ft = {
    markdown = { "injected" },
  }
})
```