### PR TITLE
fix(injected): parse injections

### DIFF
--- a/lua/conform/formatters/injected.lua
+++ b/lua/conform/formatters/injected.lua
@@ -62,7 +62,11 @@ return {
       callback("No treesitter parser for buffer")
       return
     end
-    parser:parse()
+    --- Disable diagnostic to pass the typecheck github action
+    --- This is available on nightly, but not on stable
+    --- Stable doesn't have any parameters, so it's safe to always pass `true`
+    ---@diagnostic disable-next-line: redundant-parameter
+    parser:parse(true)
     local root_lang = parser:lang()
     local regions = {}
     for lang, child_tree in pairs(parser:children()) do


### PR DESCRIPTION
On nightly, the injected formatter doesn't work.

`parse(true)` needs to be used to parse injections.
See also https://github.com/folke/noice.nvim/pull/571

Caused by upstream change: https://github.com/neovim/neovim/commit/2ca076e45fb3f1c08f6a1a374834df0701b8d778