### PR TITLE
fix(injected): prevent injected failures from halting all formatting

### DIFF
--- a/lua/conform/runner.lua
+++ b/lua/conform/runner.lua
@@ -632,7 +632,11 @@ M.format_lines_sync = function(bufnr, formatters, timeout_ms, range, input_lines
     end
 
     if not result then
-      return run_err
+      if formatter.name == "injected" then
+        result = input_lines
+      else
+        return run_err
+      end
     end
 
     input_lines = result


### PR DESCRIPTION
If an injected formatter errors, it will now keep the changed lines the same without returning an error out of the function.

Fixes #111