### PR TITLE
feat: expose configuration options for injected formatter

### DIFF
--- a/lua/conform/init.lua
+++ b/lua/conform/init.lua
@@ -19,8 +19,8 @@ local M = {}
 ---@field env? table<string, any>|fun(ctx: conform.Context): table<string, any>
 
 ---@class (exact) conform.LuaFormatterConfig
----@field format fun(ctx: conform.Context, lines: string[], callback: fun(err: nil|string, new_lines: nil|string[]))
----@field condition? fun(ctx: conform.Context): boolean
+---@field format fun(self: conform.LuaFormatterConfig, ctx: conform.Context, lines: string[], callback: fun(err: nil|string, new_lines: nil|string[]))
+---@field condition? fun(self: conform.LuaFormatterConfig, ctx: conform.Context): boolean
 
 ---@class (exact) conform.FileLuaFormatterConfig : conform.LuaFormatterConfig
 ---@field meta conform.FormatterMeta
@@ -574,7 +574,8 @@ M.get_formatter_info = function(formatter, bufnr)
   local available = true
   local available_msg = nil
   if config.format then
-    if config.condition and not config.condition(ctx) then
+    ---@cast config conform.LuaFormatterConfig
+    if config.condition and not config:condition(ctx) then
       available = false
       available_msg = "Condition failed"
     end

--- a/lua/conform/runner.lua
+++ b/lua/conform/runner.lua
@@ -265,7 +265,7 @@ local function run_formatter(bufnr, formatter, config, ctx, input_lines, opts, c
   log.trace("Input lines: %s", input_lines)
   if config.format then
     ---@cast config conform.LuaFormatterConfig
-    local ok, err = pcall(config.format, ctx, input_lines, callback)
+    local ok, err = pcall(config.format, config, ctx, input_lines, callback)
     if not ok then
       callback({
         code = M.ERROR_CODE.RUNTIME,


### PR DESCRIPTION
closes #111

This adds a configuration option for users to optionally ignore errors in the injected formatter. To enable:

```lua
require("conform.formatters.injected").options.ignore_errors = true
```