### PR TITLE
fix(biome): do not use stdin due to biome bug with emojis

### DIFF
--- a/lua/conform/formatters/biome.lua
+++ b/lua/conform/formatters/biome.lua
@@ -5,6 +5,10 @@ return {
     description = "A toolchain for web projects, aimed to provide functionalities to maintain them.",
   },
   command = "biome",
-  stdin = true,
-  args = { "format", "--stdin-file-path", "$FILENAME" },
+
+  -- pending this bug, do not use stdin: https://github.com/biomejs/biome/issues/455
+  stdin = false,
+  args = { "format", "--write", "$FILENAME" },
+  -- stdin = true,
+  -- args = { "format", "--stdin-file-path", "$FILENAME" },
 }


### PR DESCRIPTION
Due to this bug (https://github.com/biomejs/biome/issues/455), using stdin will break some emojis. Until the bug is fixed, the biome formatter should therefore write the file in-place, since the bug does not occur in that case.