### PR TITLE
fix: prevent format-on-save autocmd from running on invalid buffers

### DIFF
--- a/lua/conform/init.lua
+++ b/lua/conform/init.lua
@@ -94,7 +94,7 @@ M.setup = function(opts)
       pattern = "*",
       group = aug,
       callback = function(args)
-        if vim.bo[args.buf].buftype ~= "" then
+        if not vim.api.nvim_buf_is_valid(args.buf) or vim.bo[args.buf].buftype ~= "" then
           return
         end
         local format_args, callback = opts.format_on_save, nil


### PR DESCRIPTION
The format-on-save autocmd was running and throwing errors on temporary or hidden buffers like those created by Fugitive's commit buffers.