### PR TITLE
fix: `shellcheck` filenames with space

### DIFF
--- a/lua/conform/formatters/shellcheck.lua
+++ b/lua/conform/formatters/shellcheck.lua
@@ -5,6 +5,6 @@ return {
     description = "A static analysis tool for shell scripts.",
   },
   command = "shellcheck",
-  args = "$FILENAME --format=diff | patch -p1 $FILENAME",
+  args = "'$FILENAME' --format=diff | patch -p1 '$FILENAME'",
   stdin = false,
 }


### PR DESCRIPTION
since we switched from `args` from a list of strings to a long string, we forgot that we also needed to quote the filename 🙈