### PR TITLE
feat: Add config for laravel/pint

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,7 +230,6 @@ You can view this list in vim with `:help conform-formatters`
 - [pg_format](https://github.com/darold/pgFormatter) - PostgreSQL SQL syntax beautifier.
 - [php_cs_fixer](https://github.com/PHP-CS-Fixer/PHP-CS-Fixer) - The PHP Coding Standards Fixer.
 - [phpcbf](https://phpqa.io/projects/phpcbf.html) - PHP Code Beautifier and Fixer fixes violations of a defined coding standard.
-- [pint](https://github.com/laravel/pint) - An opinionated PHP code style fixer for minimalists.
 - [prettier](https://github.com/prettier/prettier) - Prettier is an opinionated code formatter. It enforces a consistent style by parsing your code and re-printing it with its own rules that take the maximum line length into account, wrapping code when necessary.
 - [prettierd](https://github.com/fsouza/prettierd) - prettier, as a daemon, for ludicrous formatting speed.
 - [rubocop](https://github.com/rubocop/rubocop) - Ruby static code analyzer and formatter, based on the community Ruby style guide.

--- a/README.md
+++ b/README.md
@@ -230,6 +230,7 @@ You can view this list in vim with `:help conform-formatters`
 - [pg_format](https://github.com/darold/pgFormatter) - PostgreSQL SQL syntax beautifier.
 - [php_cs_fixer](https://github.com/PHP-CS-Fixer/PHP-CS-Fixer) - The PHP Coding Standards Fixer.
 - [phpcbf](https://phpqa.io/projects/phpcbf.html) - PHP Code Beautifier and Fixer fixes violations of a defined coding standard.
+- [pint](https://github.com/laravel/pint) - An opinionated PHP code style fixer for minimalists.
 - [prettier](https://github.com/prettier/prettier) - Prettier is an opinionated code formatter. It enforces a consistent style by parsing your code and re-printing it with its own rules that take the maximum line length into account, wrapping code when necessary.
 - [prettierd](https://github.com/fsouza/prettierd) - prettier, as a daemon, for ludicrous formatting speed.
 - [rubocop](https://github.com/rubocop/rubocop) - Ruby static code analyzer and formatter, based on the community Ruby style guide.

--- a/lua/conform/formatters/pint.lua
+++ b/lua/conform/formatters/pint.lua
@@ -4,7 +4,7 @@ local util = require("conform.util")
 return {
   meta = {
     url = "https://github.com/laravel/pint",
-    description = "Laravel Pint is an opinionated PHP code style fixer for minimalists. Pint is built on top of PHP-CS-Fixer and makes it simple to ensure that your code style stays clean and consistent.",
+    description = "Laravel Pint is an opinionated PHP code style fixer for minimalists.",
   },
   command = util.find_executable({
     "vendor/bin/pint",

--- a/lua/conform/formatters/pint.lua
+++ b/lua/conform/formatters/pint.lua
@@ -7,7 +7,6 @@ return {
     description = "Laravel Pint is an opinionated PHP code style fixer for minimalists. Pint is built on top of PHP-CS-Fixer and makes it simple to ensure that your code style stays clean and consistent.",
   },
   command = util.find_executable({
-    vim.fn.stdpath("data") .. "/mason/bin/pint",
     "vendor/bin/pint",
   }, "pint"),
   args = { "$FILENAME" },

--- a/lua/conform/formatters/pint.lua
+++ b/lua/conform/formatters/pint.lua
@@ -1,0 +1,15 @@
+local util = require("conform.util")
+
+---@type conform.FileFormatterConfig
+return {
+  meta = {
+    url = "https://github.com/laravel/pint",
+    description = "Laravel Pint is an opinionated PHP code style fixer for minimalists. Pint is built on top of PHP-CS-Fixer and makes it simple to ensure that your code style stays clean and consistent.",
+  },
+  command = util.find_executable({
+    vim.fn.stdpath("data") .. "/mason/bin/pint",
+    "vendor/bin/pint",
+  }, "pint"),
+  args = { "$FILENAME" },
+  stdin = false,
+}


### PR DESCRIPTION
This PR adds a preset for [laravel/pint](https://github.com/laravel/pint). A popular formatting tool for laravel. It has preconfigured configs for e.g. laravel and symfony code styling.

- Supports both mason and local composer install

I am not sure if using vim.fn.stdpath("data") to get to the mason install path is a good practice, as I am not too experienced with nvim scripting. Feel free to change