### PR TITLE
Change `rustfmt` formatter to work via `cargo`

### DIFF
--- a/lua/conform/formatters/rustfmt.lua
+++ b/lua/conform/formatters/rustfmt.lua
@@ -4,6 +4,6 @@ return {
     url = "https://github.com/rust-lang/rustfmt",
     description = "A tool for formatting rust code according to style guidelines.",
   },
-  command = "rustfmt",
-  args = { "--emit=stdout" },
+  command = "cargo",
+	args = { "fmt", "--", "-q", "--emit=stdout" },
 }


### PR DESCRIPTION
Invoking `rustfmt` directly does not apply the settings set in `Cargo.toml`, like the Rust edition the file is using.

This pull request changes the command that was being used to the equivalent `cargo`, which uses `rustfmt` under the hood.