### PR TITLE
feat: add mdslw markdown formatter

### DIFF
--- a/lua/conform/formatters/mdslw.lua
+++ b/lua/conform/formatters/mdslw.lua
@@ -1,4 +1,3 @@
-local util = require("conform.util")
 ---@type conform.FileFormatterConfig
 return {
   meta = {

--- a/lua/conform/formatters/mdslw.lua
+++ b/lua/conform/formatters/mdslw.lua
@@ -1,0 +1,9 @@
+local util = require("conform.util")
+---@type conform.FileFormatterConfig
+return {
+  meta = {
+    url = "https://github.com/razziel89/mdslw",
+    description = "Prepare your markdown for easy diff'ing by adding line breaks after every sentence.",
+  },
+  command = "mdslw",
+}


### PR DESCRIPTION
With this PR, I would like to suggest the addition of the markdown auto-formatter `mdslw`. I am already using `mdslw` with `conform.nvim` and was wondering whether it could be added to the official list of available tools. Before creating this PR, I was wondering whether there were any prerequisites for having an auto-formatter added to `conform.nvim`, but I could not find any information in the docs.

Disclaimer: I am the author of `mdslw` ([repo link](https://github.com/razziel89/mdslw)).

In some other PR, I read that only the lua files were mandatory and all the rest would be generated automatically. I hope I understood that correctly. If you would like to see any changes to this PR, please let me know and I will incorporate them. I would be grateful if you could consider this PR.