### PR TITLE
fix: remove unnecessary `resolve_formatters` call in injected formatter

### DIFF
--- a/lua/conform/formatters/injected.lua
+++ b/lua/conform/formatters/injected.lua
@@ -170,12 +170,9 @@ return {
         num_format = num_format + 1
         last_start_lnum = start_lnum
         local input_lines = util.tbl_slice(lines, start_lnum, end_lnum)
-        local ft_formatters = conform.formatters_by_ft[lang]
-        local formatter_names
-        if type(ft_formatters) == "function" then
-          formatter_names = ft_formatters(ctx.buf)
-        else
-          formatter_names = require("conform").resolve_formatters(ft_formatters, ctx.buf, false)
+        local formatter_names = conform.formatters_by_ft[lang]
+        if type(formatter_names) == "function" then
+          formatter_names = formatter_names(ctx.buf)
         end
         local format_opts = { async = true, bufnr = ctx.buf, quiet = true }
         local idx = num_format


### PR DESCRIPTION
It looks like this is already being handled in the `format_lines` call. We just need the names here

Resolves #187 