### PR TITLE
chore(biome): switch back to stdin due to upstream fix

### DIFF
--- a/lua/conform/formatters/biome.lua
+++ b/lua/conform/formatters/biome.lua
@@ -5,10 +5,6 @@ return {
     description = "A toolchain for web projects, aimed to provide functionalities to maintain them.",
   },
   command = "biome",
-
-  -- pending this bug, do not use stdin: https://github.com/biomejs/biome/issues/455
-  stdin = false,
-  args = { "format", "--write", "$FILENAME" },
-  -- stdin = true,
-  -- args = { "format", "--stdin-file-path", "$FILENAME" },
+  stdin = true,
+  args = { "format", "--stdin-file-path", "$FILENAME" },
 }


### PR DESCRIPTION
https://github.com/biomejs/biome/issues/455, which was fixed, therefore the temporary fix #120 can be reverted.

(Marking this is Draft PR since the biome fix was merged, but not yet released. Can be merged with the next biome release)