### PR TITLE
feat: add cbfmt

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ You can view this list in vim with `:help conform-formatters`
 - [blade-formatter](https://github.com/shufo/blade-formatter) - An opinionated blade template formatter for Laravel that respects readability.
 - [blue](https://github.com/grantjenks/blue) - The slightly less uncompromising Python code formatter.
 - [buf](https://buf.build/docs/reference/cli/buf/format) - A new way of working with Protocol Buffers.
+- [cbfmt](https://github.com/lukas-reineke/cbfmt) - A tool to format codeblocks inside markdown and org documents.
 - [clang_format](https://www.kernel.org/doc/html/latest/process/clang-format.html) - Tool to format C/C++/… code according to a set of rules and heuristics.
 - [cljstyle](https://github.com/greglook/cljstyle) - Formatter for Clojure code.
 - [cmake_format](https://github.com/cheshirekow/cmake_format) - Parse cmake listfiles and format them nicely.

--- a/lua/conform/formatters/cbfmt.lua
+++ b/lua/conform/formatters/cbfmt.lua
@@ -6,7 +6,7 @@ return {
     description = "A tool to format codeblocks inside markdown and org documents.",
   },
   command = "cbfmt",
-  args = { "--write", "--best-effort", "$FILENAME", },
+  args = { "--write", "--best-effort", "$FILENAME" },
   cwd = util.root_file({
     -- https://github.com/lukas-reineke/cbfmt#config
     ".cbfmt.toml",

--- a/lua/conform/formatters/cbfmt.lua
+++ b/lua/conform/formatters/cbfmt.lua
@@ -1,0 +1,15 @@
+local util = require("conform.util")
+---@type conform.FileFormatterConfig
+return {
+  meta = {
+    url = "https://github.com/lukas-reineke/cbfmt",
+    description = "A tool to format codeblocks inside markdown and org documents.",
+  },
+  command = "cbfmt",
+  args = { "--write", "--best-effort", "$FILENAME", },
+  cwd = util.root_file({
+    -- https://github.com/lukas-reineke/cbfmt#config
+    ".cbfmt.toml",
+  }),
+  stdin = false,
+}


### PR DESCRIPTION
Added support for [cbfmt](https://github.com/lukas-reineke/cbfmt) formatter to format codeblocks inside markdown and org documents