### PR TITLE
chore: remove $FILENAME from standardjs formatter config

### DIFF
--- a/lua/conform/formatters/standardjs.lua
+++ b/lua/conform/formatters/standardjs.lua
@@ -7,5 +7,5 @@ return {
     description = "JavaScript Standard style guide, linter, and formatter.",
   },
   command = util.from_node_modules("standard"),
-  args = { "--fix", "--stdin", "$FILENAME" },
+  args = { "--fix", "--stdin" },
 }


### PR DESCRIPTION
I've removed the `$FILENAME` argument from the **standardjs** formatter configuration. It's not needed with the `--stdin` flag.