### PR TITLE
Use the filetype rather than the filename for setting the parser

### DIFF
--- a/lua/conform/formatters/injected.lua
+++ b/lua/conform/formatters/injected.lua
@@ -226,6 +226,8 @@ return {
         -- This is using the language name as the file extension, but that is a reasonable
         -- approximation for now. We can add special cases as the need arises.
         local buf = vim.fn.bufadd(string.format("%s.%s", vim.api.nvim_buf_get_name(ctx.buf), lang))
+        -- Actually load the buffer to set the buffer context which is required by some formatters such as `filetype`
+        vim.fn.bufload(buf)
         tmp_bufs[buf] = true
         local format_opts = { async = true, bufnr = buf, quiet = true }
         conform.format_lines(formatter_names, input_lines, format_opts, function(err, new_lines)

--- a/lua/conform/formatters/prettier.lua
+++ b/lua/conform/formatters/prettier.lua
@@ -6,10 +6,17 @@ return {
     description = [[Prettier is an opinionated code formatter. It enforces a consistent style by parsing your code and re-printing it with its own rules that take the maximum line length into account, wrapping code when necessary.]],
   },
   command = util.from_node_modules("prettier"),
-  args = { "--stdin-filepath", "$FILENAME" },
+  args = function(ctx)
+    return { "--parser=" .. vim.bo[ctx.buf].filetype }
+  end,
   range_args = function(ctx)
     local start_offset, end_offset = util.get_offsets_from_range(ctx.buf, ctx.range)
-    return { "$FILENAME", "--range-start=" .. start_offset, "--range-end=" .. end_offset }
+    return {
+      "$FILENAME",
+      "--parser=" .. vim.bo[ctx.buf].filetype,
+      "--range-start=" .. start_offset,
+      "--range-end=" .. end_offset,
+    }
   end,
   cwd = util.root_file({
     -- https://prettier.io/docs/en/configuration.html


### PR DESCRIPTION
this also fixes the `injected` formatter to actually load the new temp buffer it creates so that things like `filetype` are set which are required by some formatters.

I looked to add this to `prettierd` but it doesn't have the option to specify a specific language parser and will only infer it from the filename