### PR TITLE
fix: various fixes for the `injected` formatter

### DIFF
--- a/lua/conform/formatters/injected.lua
+++ b/lua/conform/formatters/injected.lua
@@ -74,9 +74,10 @@ return {
     ignore_errors = false,
   },
   condition = function(self, ctx)
-    local ok = pcall(vim.treesitter.get_parser, ctx.buf)
+    local ok, parser = pcall(vim.treesitter.get_parser, ctx.buf)
     -- Require Neovim 0.9 because the treesitter API has changed significantly
-    return ok and vim.fn.has("nvim-0.9") == 1
+    ---@diagnostic disable-next-line: invisible
+    return ok and parser._injection_query and vim.fn.has("nvim-0.9") == 1
   end,
   format = function(self, ctx, lines, callback)
     local conform = require("conform")

--- a/lua/conform/formatters/injected.lua
+++ b/lua/conform/formatters/injected.lua
@@ -226,6 +226,8 @@ return {
         -- This is using the language name as the file extension, but that is a reasonable
         -- approximation for now. We can add special cases as the need arises.
         local buf = vim.fn.bufadd(string.format("%s.%s", vim.api.nvim_buf_get_name(ctx.buf), lang))
+        -- Actually load the buffer to set the buffer context which is required by some formatters such as `filetype`
+        vim.fn.bufload(buf)
         tmp_bufs[buf] = true
         local format_opts = { async = true, bufnr = buf, quiet = true }
         conform.format_lines(formatter_names, input_lines, format_opts, function(err, new_lines)


### PR DESCRIPTION
Some formatters rely on information such as `filetype`. If that one of those formatters are used by the `injected` formatter, we need to load the buffer of the injected so that it calculates information such as `filetype`.

This also validates that `_injection_query` exists before enabling the `injected` formatter. Not all treesitter parsers provide this query if they do not have any possible language injections. One example of this is the `json` parser which doesn't have any injections. This will tell the parser that it doesn't actually need to run for buffers with parsers without injections.