### PR TITLE
fix(formatexpr)!: do not fallback to the built-in formatter

### DIFF
--- a/lua/conform/init.lua
+++ b/lua/conform/init.lua
@@ -719,7 +719,8 @@ M.formatexpr = function(opts)
     -- No formatters were available; fall back to lsp formatter
     return vim.lsp.formatexpr({ timeout_ms = opts.timeout_ms })
   else
-    return 1
+    -- Do not fallback to built-in formatter.
+    return 0
   end
 end
 


### PR DESCRIPTION
This makes the behavior of formatexpr more consistent with
`vim.lsp.formatexpr`; do not run vim's builtin formatter.

Problem: When conform's formatexpr is used and (range or buffer) but
conform can't do formatting and there is no LSP server with the
formatting capabilities, it will fall back to the (wrong) built-in
formatting, which might result in simply concatenating all the words.

This is a breaking change (as a part of v5.0 with breaking change),
reverting the behavior introduced in 278bcd8bf2017e187e963b515017341fdd87fe2f (#55). /cc @cryptomilk 


