### PR TITLE
feat: add hindent for haskell formatting

### DIFF
--- a/lua/conform/formatters/hindent.lua
+++ b/lua/conform/formatters/hindent.lua
@@ -1,0 +1,9 @@
+---@type conform.FileFormatterConfig
+return {
+  meta = {
+    url = "https://hackage.haskell.org/package/hindent",
+    description = "Extensible Haskell pretty printer.",
+  },
+  command = "hindent",
+  args = { "$FILENAME" },
+}


### PR DESCRIPTION
I'm unsure what `stdin = true` means so I excluded it. Is it necessary?