### PR TITLE
Execute rubocop via rubocop's server

### DIFF
--- a/lua/conform/formatters/rubocop.lua
+++ b/lua/conform/formatters/rubocop.lua
@@ -6,6 +6,7 @@ return {
   },
   command = "rubocop",
   args = {
+    "--server",
     "-a",
     "-f",
     "quiet",


### PR DESCRIPTION
This ensures a much quicker execution on 2nd and any subsequent run. Otherwise there's always a 1-3 seconds delay before formatting is being applied (as rubocop is not that quick).

From rubocop's documentation:

```
--server If a server process has not been started yet, start the server process and execute inspection with server.
```

([documentation](https://docs.rubocop.org/rubocop/usage/server.html))

I've tested it locally with custom defined formatter and it resulted in a much quicker execution on subsequent runs. Best if someone else also tested this to confirm my observations.

An even better approach would be to use the [LSP server](https://docs.rubocop.org/rubocop/usage/lsp.html), but I'm not sure how to achieve that (specifying the `--lsp` option wipes the buffer on each conform run for me).