### PR TITLE
feat: add fnlfmt formatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,7 @@ You can view this list in vim with `:help conform-formatters`
 - [eslint_d](https://github.com/mantoni/eslint_d.js/) - Like ESLint, but faster.
 - [fish_indent](https://fishshell.com/docs/current/cmds/fish_indent.html) - Indent or otherwise prettify a piece of fish code.
 - [fixjson](https://github.com/rhysd/fixjson) - JSON Fixer for Humans using (relaxed) JSON5.
+- [fnlfmt](https://git.sr.ht/~technomancy/fnlfmt) - A formatter for Fennel code.
 - [fourmolu](https://hackage.haskell.org/package/fourmolu) - Fourmolu is a formatter for Haskell source code.
 - [gci](https://github.com/daixiang0/gci) - GCI, a tool that controls Go package import order and makes it always deterministic.
 - [gdformat](https://github.com/Scony/godot-gdscript-toolkit) - A formatter for Godot's gdscript.

--- a/lua/conform/formatters/fnlfmt.lua
+++ b/lua/conform/formatters/fnlfmt.lua
@@ -1,0 +1,9 @@
+--@type conform.FileFormatterConfig
+return {
+  meta = {
+    url = "https://git.sr.ht/~technomancy/fnlfmt",
+    description = "A formatter for Fennel code.",
+  },
+  command = "fnlfmt",
+  args = { "-" },
+}


### PR DESCRIPTION
Note: latest tagged version `0.3.1` contains a bug that causes the output to contain an extra newline at the end. This is fixed on upstream `main` branch and pending release: https://git.sr.ht/~technomancy/fnlfmt/commit/d8f950865a00dcabc092c39a1127144e0d62d0c4