### PR TITLE
fix: injected formatter handles inline injections

### DIFF
--- a/.github/workflows/automation_remove_question_label_on_comment.yml
+++ b/.github/workflows/automation_remove_question_label_on_comment.yml
@@ -8,6 +8,7 @@ jobs:
   # issues in my "needs triage" filter.
   remove_question:
     runs-on: ubuntu-latest
+    if: github.event.sender.login != 'stevearc'
     steps:
       - uses: actions/checkout@v2
       - uses: actions-ecosystem/action-remove-labels@v1

--- a/lua/conform/formatters/injected.lua
+++ b/lua/conform/formatters/injected.lua
@@ -60,8 +60,31 @@ local function apply_indent(lines, indentation)
   end
 end
 
+---@class LangRange
+---@field [1] string language
+---@field [2] integer start lnum
+---@field [3] integer start col
+---@field [4] integer end lnum
+---@field [5] integer end col
+
+---@param ranges LangRange[]
+---@param range LangRange
+local function accum_range(ranges, range)
+  local last_range = ranges[#ranges]
+  if last_range then
+    if last_range[1] == range[1] and last_range[4] == range[2] and last_range[5] == range[3] then
+      last_range[4] = range[4]
+      last_range[5] = range[5]
+      return
+    end
+  end
+  table.insert(ranges, range)
+end
+
 ---@class (exact) conform.InjectedFormatterOptions
 ---@field ignore_errors boolean
+---@field lang_to_ext table<string, string>
+---@field lang_to_formatters table<string, conform.FiletypeFormatter>
 
 ---@type conform.FileLuaFormatterConfig
 return {
@@ -72,6 +95,26 @@ return {
   options = {
     -- Set to true to ignore errors
     ignore_errors = false,
+    -- Map of treesitter language to file extension
+    -- A temporary file name with this extension will be generated during formatting
+    -- because some formatters care about the filename.
+    lang_to_ext = {
+      bash = "sh",
+      c_sharp = "cs",
+      elixir = "exs",
+      javascript = "js",
+      julia = "jl",
+      latex = "tex",
+      markdown = "md",
+      python = "py",
+      ruby = "rb",
+      rust = "rs",
+      teal = "tl",
+      typescript = "ts",
+    },
+    -- Map of treesitter language to formatters to use
+    -- (defaults to the value from formatters_by_ft)
+    lang_to_formatters = {},
   },
   condition = function(self, ctx)
     local ok, parser = pcall(vim.treesitter.get_parser, ctx.buf)
@@ -93,12 +136,20 @@ return {
     end
     ---@type conform.InjectedFormatterOptions
     local options = self.options
+
+    ---@param lang string
+    ---@return nil|conform.FiletypeFormatter
+    local function get_formatters(lang)
+      return options.lang_to_formatters[lang] or conform.formatters_by_ft[lang]
+    end
+
     --- Disable diagnostic to pass the typecheck github action
     --- This is available on nightly, but not on stable
     --- Stable doesn't have any parameters, so it's safe to always pass `false`
     ---@diagnostic disable-next-line: redundant-parameter
     parser:parse(false)
     local root_lang = parser:lang()
+    ---@type LangRange[]
     local regions = {}
 
     for _, tree in pairs(parser:trees()) do
@@ -124,24 +175,24 @@ return {
       do
         ---@diagnostic disable-next-line: invisible
         local lang, combined, ranges = parser:_get_injection(match, metadata)
-        local has_formatters = conform.formatters_by_ft[lang] ~= nil
-        if lang and has_formatters and not combined and #ranges > 0 and lang ~= root_lang then
-          local start_lnum
-          local end_lnum
-          -- Merge all of the ranges into a single range
+        if
+          lang
+          and get_formatters(lang) ~= nil
+          and not combined
+          and #ranges > 0
+          and lang ~= root_lang
+        then
           for _, range in ipairs(ranges) do
-            if not start_lnum or start_lnum > range[1] + 1 then
-              start_lnum = range[1] + 1
-            end
-            if not end_lnum or end_lnum < range[4] then
-              end_lnum = range[4]
-            end
-          end
-          if in_range(ctx.range, start_lnum, end_lnum) then
-            table.insert(regions, { lang, start_lnum, end_lnum })
+            accum_range(regions, { lang, range[1] + 1, range[2], range[4] + 1, range[5] })
           end
         end
       end
+    end
+
+    if ctx.range then
+      regions = vim.tbl_filter(function(region)
+        return in_range(ctx.range, region[2], region[4])
+      end, regions)
     end
 
     -- Sort from largest start_lnum to smallest
@@ -171,7 +222,11 @@ return {
 
       local formatted_lines = vim.deepcopy(lines)
       for _, replacement in ipairs(replacements) do
-        local start_lnum, end_lnum, new_lines = unpack(replacement)
+        local start_lnum, start_col, end_lnum, end_col, new_lines = unpack(replacement)
+        local prefix = formatted_lines[start_lnum]:sub(1, start_col)
+        local suffix = formatted_lines[end_lnum]:sub(end_col + 1)
+        new_lines[1] = prefix .. new_lines[1]
+        new_lines[#new_lines] = new_lines[#new_lines] .. suffix
         for _ = start_lnum, end_lnum do
           table.remove(formatted_lines, start_lnum)
         end
@@ -184,12 +239,20 @@ return {
 
     local num_format = 0
     local tmp_bufs = {}
-    local formatter_cb = function(err, idx, start_lnum, end_lnum, new_lines)
+    local formatter_cb = function(err, idx, region, input_lines, new_lines)
       if err then
         format_error = errors.coalesce(format_error, err)
         replacements[idx] = err
       else
-        replacements[idx] = { start_lnum, end_lnum, new_lines }
+        -- If the original lines started/ended with a newline, preserve that newline.
+        -- Many formatters will trim them, but they're important for the document structure.
+        if input_lines[1] == "" and new_lines[1] ~= "" then
+          table.insert(new_lines, 1, "")
+        end
+        if input_lines[#input_lines] == "" and new_lines[#new_lines] ~= "" then
+          table.insert(new_lines, "")
+        end
+        replacements[idx] = { region[2], region[3], region[4], region[5], new_lines }
       end
       num_format = num_format - 1
       if num_format == 0 then
@@ -200,14 +263,22 @@ return {
       end
     end
     local last_start_lnum = #lines + 1
-    for _, region in ipairs(regions) do
-      local lang, start_lnum, end_lnum = unpack(region)
+    for i, region in ipairs(regions) do
+      local lang = region[1]
+      local start_lnum = region[2]
+      local start_col = region[3]
+      local end_lnum = region[4]
+      local end_col = region[5]
       -- Ignore regions that overlap (contain) other regions
       if end_lnum < last_start_lnum then
         num_format = num_format + 1
         last_start_lnum = start_lnum
         local input_lines = util.tbl_slice(lines, start_lnum, end_lnum)
-        local ft_formatters = conform.formatters_by_ft[lang]
+        input_lines[#input_lines] = input_lines[#input_lines]:sub(1, end_col)
+        if start_col > 0 then
+          input_lines[1] = input_lines[1]:sub(start_col + 1)
+        end
+        local ft_formatters = assert(get_formatters(lang))
         ---@type string[]
         local formatter_names
         if type(ft_formatters) == "function" then
@@ -226,15 +297,18 @@ return {
         -- extension to determine a run mode (see https://github.com/stevearc/conform.nvim/issues/194)
         -- This is using the language name as the file extension, but that is a reasonable
         -- approximation for now. We can add special cases as the need arises.
-        local buf = vim.fn.bufadd(string.format("%s.%s", vim.api.nvim_buf_get_name(ctx.buf), lang))
+        local extension = options.lang_to_ext[lang] or lang
+        local buf =
+          vim.fn.bufadd(string.format("%s.%d.%s", vim.api.nvim_buf_get_name(ctx.buf), i, extension))
         -- Actually load the buffer to set the buffer context which is required by some formatters such as `filetype`
         vim.fn.bufload(buf)
         tmp_bufs[buf] = true
         local format_opts = { async = true, bufnr = buf, quiet = true }
         conform.format_lines(formatter_names, input_lines, format_opts, function(err, new_lines)
+          log.trace("Injected %s:%d:%d formatted lines %s", lang, start_lnum, end_lnum, new_lines)
           -- Preserve indentation in case the code block is indented
           apply_indent(new_lines, indent)
-          formatter_cb(err, idx, start_lnum, end_lnum, new_lines)
+          vim.schedule_wrap(formatter_cb)(err, idx, region, input_lines, new_lines)
         end)
       end
     end

--- a/lua/conform/fs.lua
+++ b/lua/conform/fs.lua
@@ -15,4 +15,24 @@ M.join = function(...)
   return table.concat({ ... }, M.sep)
 end
 
+---@param filepath string
+---@return boolean
+M.exists = function(filepath)
+  local stat = uv.fs_stat(filepath)
+  return stat ~= nil and stat.type ~= nil
+end
+
+---@param filepath string
+---@return string?
+M.read_file = function(filepath)
+  if not M.exists(filepath) then
+    return nil
+  end
+  local fd = assert(uv.fs_open(filepath, "r", 420)) -- 0644
+  local stat = assert(uv.fs_fstat(fd))
+  local content = uv.fs_read(fd, stat.size)
+  uv.fs_close(fd)
+  return content
+end
+
 return M

--- a/lua/conform/runner.lua
+++ b/lua/conform/runner.lua
@@ -342,6 +342,7 @@ local function run_formatter(bufnr, formatter, config, ctx, input_lines, opts, c
         end
         log.debug("%s exited with code %d", formatter.name, code)
         log.trace("Output lines: %s", output)
+        log.trace("%s stderr: %s", formatter.name, stderr)
         callback(nil, output)
       else
         log.info("%s exited with code %d", formatter.name, code)

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -14,11 +14,17 @@ else
   (cd "$PLUGINS/plenary.nvim" && git pull)
 fi
 
+if [ ! -e "$PLUGINS/nvim-treesitter" ]; then
+  git clone --depth=1 https://github.com/nvim-treesitter/nvim-treesitter.git "$PLUGINS/nvim-treesitter"
+else
+  (cd "$PLUGINS/nvim-treesitter" && git pull)
+fi
+
 XDG_CONFIG_HOME=".testenv/config" \
   XDG_DATA_HOME=".testenv/data" \
   XDG_STATE_HOME=".testenv/state" \
   XDG_RUNTIME_DIR=".testenv/run" \
   XDG_CACHE_HOME=".testenv/cache" \
   nvim --headless -u tests/minimal_init.lua \
-  -c "PlenaryBustedDirectory ${1-tests} { minimal_init = './tests/minimal_init.lua' }"
+  -c "RunTests ${1-tests}"
 echo "Success"

--- a/tests/fake_formatter.sh
+++ b/tests/fake_formatter.sh
@@ -2,16 +2,24 @@
 
 set -e
 
-if [ -e "tests/fake_formatter_output" ]; then
-	cat tests/fake_formatter_output
-else
-	cat
-fi
-
+CODE=0
 if [ "$1" = "--fail" ]; then
-	echo "failure" >&2
-	exit 1
-elif [ "$1" = "--timeout" ]; then
-	sleep 4
+  shift
+  echo "failure" >&2
+  CODE=1
+fi
+if [ "$1" = "--timeout" ]; then
+  shift
+  echo "timeout" >&2
+  sleep 4
 fi
 
+output_file="$1"
+
+if [ -n "$output_file" ] && [ -e "$output_file" ]; then
+  cat "$output_file"
+else
+  cat
+fi
+
+exit $CODE

--- a/tests/injected/block_quote.md
+++ b/tests/injected/block_quote.md
@@ -1,0 +1,5 @@
+text
+
+> ```lua
+> local foo = 'bar'
+> ```

--- a/tests/injected/block_quote.md.formatted
+++ b/tests/injected/block_quote.md.formatted
@@ -1,0 +1,5 @@
+text
+
+> ```lua
+> |local foo = 'bar'|
+> ```

--- a/tests/injected/combined_injections.md
+++ b/tests/injected/combined_injections.md
@@ -1,0 +1,14 @@
+text
+
+<!-- comment -->
+
+```lua
+local foo = 'bar'
+```
+
+
+<!-- comment -->
+
+```lua
+local foo = 'bar'
+```

--- a/tests/injected/combined_injections.md.formatted
+++ b/tests/injected/combined_injections.md.formatted
@@ -1,0 +1,14 @@
+text
+
+<!-- comment -->
+
+```lua
+|local foo = 'bar'|
+```
+
+
+<!-- comment -->
+
+```lua
+|local foo = 'bar'|
+```

--- a/tests/injected/inline.ts
+++ b/tests/injected/inline.ts
@@ -1,0 +1,5 @@
+foo.innerHTML = `<div> hello </div>`;
+
+bar.innerHTML = `
+<div> world </div>
+`;

--- a/tests/injected/inline.ts.formatted
+++ b/tests/injected/inline.ts.formatted
@@ -1,0 +1,5 @@
+foo.innerHTML = `|<div> hello </div>|`;
+
+bar.innerHTML = `
+|<div> world </div>|
+`;

--- a/tests/injected/simple.md
+++ b/tests/injected/simple.md
@@ -1,0 +1,5 @@
+text
+
+```lua
+local foo = 'bar'
+```

--- a/tests/injected/simple.md.formatted
+++ b/tests/injected/simple.md.formatted
@@ -1,0 +1,5 @@
+text
+
+```lua
+|local foo = 'bar'|
+```

--- a/tests/injected_spec.lua
+++ b/tests/injected_spec.lua
@@ -1,0 +1,91 @@
+require("plenary.async").tests.add_to_env()
+local conform = require("conform")
+local fs = require("conform.fs")
+local injected = require("conform.formatters.injected")
+local runner = require("conform.runner")
+local test_util = require("tests.test_util")
+
+-- injected formatter only supported on neovim 0.9+
+if vim.fn.has("nvim-0.9") == 0 then
+  return
+end
+
+---@param dir string
+---@return string[]
+local function list_test_files(dir)
+  ---@diagnostic disable-next-line: param-type-mismatch
+  local fd = vim.loop.fs_opendir(dir, nil, 32)
+  ---@diagnostic disable-next-line: param-type-mismatch
+  local entries = vim.loop.fs_readdir(fd)
+  local ret = {}
+  while entries do
+    for _, entry in ipairs(entries) do
+      if entry.type == "file" and not vim.endswith(entry.name, ".formatted") then
+        table.insert(ret, entry.name)
+      end
+    end
+    ---@diagnostic disable-next-line: param-type-mismatch
+    entries = vim.loop.fs_readdir(fd)
+  end
+  ---@diagnostic disable-next-line: param-type-mismatch
+  vim.loop.fs_closedir(fd)
+  return ret
+end
+
+describe("injected formatter", function()
+  before_each(function()
+    -- require("conform.log").level = vim.log.levels.TRACE
+    conform.formatters_by_ft = {
+      lua = { "test_mark" },
+      html = { "test_mark" },
+    }
+    -- A test formatter that bookends lines with "|" so we can check what was passed in
+    conform.formatters.test_mark = {
+      format = function(self, ctx, lines, callback)
+        local ret = {}
+        for i, line in ipairs(lines) do
+          if i == 1 and line == "" then
+            -- Simulate formatters removing starting newline
+          elseif i == #lines and line == "" then
+            -- Simulate formatters removing trailing newline
+          else
+            table.insert(ret, "|" .. line:gsub("%s+", " ") .. "|")
+          end
+        end
+        callback(nil, ret)
+      end,
+    }
+  end)
+
+  after_each(function()
+    test_util.reset_editor()
+  end)
+
+  for _, filename in ipairs(list_test_files("tests/injected")) do
+    local filepath = "./tests/injected/" .. filename
+    local formatted_file = filepath .. ".formatted"
+    it(filename, function()
+      local content = fs.read_file(filepath)
+      assert(content)
+      local lines = vim.split(content, "\n", { plain = true })
+      local bufnr = vim.fn.bufadd(filepath)
+      vim.fn.bufload(bufnr)
+      local config = assert(conform.get_formatter_config("injected", bufnr))
+      local ctx = runner.build_context(bufnr, config)
+      local err, new_lines, done
+      injected.format(injected, ctx, lines, function(e, formatted)
+        done = true
+        err = e
+        new_lines = formatted
+      end)
+      vim.wait(1000, function()
+        return done
+      end)
+      assert(err == nil, err)
+      local expected = fs.read_file(formatted_file)
+      assert(expected)
+      local expected_lines = vim.split(expected, "\n", { plain = true })
+      assert.are.same(expected_lines, new_lines)
+    end)
+  end
+end)

--- a/tests/minimal_init.lua
+++ b/tests/minimal_init.lua
@@ -3,3 +3,19 @@ vim.cmd([[set runtimepath+=.]])
 vim.o.swapfile = false
 vim.bo.swapfile = false
 require("tests.test_util").reset_editor()
+
+local configs = require("nvim-treesitter.configs")
+configs.setup({
+  ensure_installed = { "markdown", "markdown_inline", "lua", "typescript", "html" },
+  sync_install = true,
+})
+-- this needs to be run a second time to make tests behave
+require("nvim-treesitter").setup()
+
+vim.api.nvim_create_user_command("RunTests", function(opts)
+  local path = opts.fargs[1] or "tests"
+  require("plenary.test_harness").test_directory(
+    path,
+    { minimal_init = "./tests/minimal_init.lua" }
+  )
+end, { nargs = "?" })

--- a/tests/runner_spec.lua
+++ b/tests/runner_spec.lua
@@ -2,10 +2,35 @@ require("plenary.async").tests.add_to_env()
 local conform = require("conform")
 local runner = require("conform.runner")
 local test_util = require("tests.test_util")
+local util = require("conform.util")
 
 describe("runner", function()
+  local OUTPUT_FILE
+  local CLEANUP_FILES = {}
+
+  ---@param lines string[]
+  local function set_formatter_output(lines)
+    local fd, output_file = vim.loop.fs_mkstemp(".testenv/outputXXXXXXXXX")
+    assert(type(fd) == "number" and output_file, fd)
+    local content = table.concat(lines, "\n")
+    vim.loop.fs_write(fd, content)
+    -- Make sure we add the final newline
+    vim.loop.fs_write(fd, "\n")
+    vim.loop.fs_fsync(fd)
+    vim.loop.fs_close(fd)
+    OUTPUT_FILE = output_file
+    table.insert(CLEANUP_FILES, output_file)
+  end
+
   after_each(function()
     test_util.reset_editor()
+    OUTPUT_FILE = nil
+    for _, file in ipairs(CLEANUP_FILES) do
+      if vim.loop.fs_stat(file) then
+        vim.loop.fs_unlink(file)
+      end
+    end
+    CLEANUP_FILES = {}
   end)
 
   it("resolves config function", function()
@@ -151,6 +176,12 @@ describe("runner", function()
     before_each(function()
       conform.formatters.test = {
         command = "tests/fake_formatter.sh",
+        args = function()
+          if OUTPUT_FILE then
+            return { OUTPUT_FILE }
+          end
+          return {}
+        end,
       }
     end)
 
@@ -165,7 +196,7 @@ describe("runner", function()
       vim.api.nvim_buf_set_lines(bufnr, 0, -1, true, lines)
       vim.bo[bufnr].modified = false
       local expected_lines = vim.split(expected, "\n", { plain = true })
-      test_util.set_formatter_output(expected_lines)
+      set_formatter_output(expected_lines)
       conform.format(vim.tbl_extend("keep", opts or {}, { formatters = { "test" }, quiet = true }))
       return expected_lines
     end
@@ -240,19 +271,19 @@ print("a")
     end)
 
     it("does not change output if formatter fails", function()
-      conform.formatters.test.args = { "--fail" }
+      conform.formatters.test.args = util.extend_args(conform.formatters.test.args, { "--fail" })
       run_formatter("hello", "goodbye")
       assert.are.same({ "hello" }, vim.api.nvim_buf_get_lines(0, 0, -1, false))
     end)
 
     it("allows nonzero exit codes", function()
-      conform.formatters.test.args = { "--fail" }
+      conform.formatters.test.args = util.extend_args(conform.formatters.test.args, { "--fail" })
       conform.formatters.test.exit_codes = { 0, 1 }
       run_formatter_test("hello", "goodbye")
     end)
 
     it("does not format if it times out", function()
-      conform.formatters.test.args = { "--timeout" }
+      conform.formatters.test.args = util.extend_args(conform.formatters.test.args, { "--timeout" })
       run_formatter("hello", "goodbye", { timeout_ms = 10 })
       assert.are.same({ "hello" }, vim.api.nvim_buf_get_lines(0, 0, -1, false))
     end)
@@ -260,7 +291,9 @@ print("a")
     it("can format async", function()
       run_formatter("hello", "goodbye", { async = true })
       assert.are.same({ "hello" }, vim.api.nvim_buf_get_lines(0, 0, -1, false))
-      vim.wait(100)
+      vim.wait(1000, function()
+        return vim.api.nvim_buf_get_lines(0, 0, -1, false)[1] == "goodbye"
+      end)
       assert.are.same({ "goodbye" }, vim.api.nvim_buf_get_lines(0, 0, -1, false))
     end)
 
@@ -268,7 +301,9 @@ print("a")
       run_formatter("hello", "goodbye", { async = true })
       assert.are.same({ "hello" }, vim.api.nvim_buf_get_lines(0, 0, -1, false))
       vim.api.nvim_buf_set_lines(0, 0, -1, true, { "newcontent" })
-      vim.wait(100)
+      vim.wait(1000, function()
+        return vim.api.nvim_buf_get_lines(0, 0, -1, false)[1] == "newcontent"
+      end)
       assert.are.same({ "newcontent" }, vim.api.nvim_buf_get_lines(0, 0, -1, false))
     end)
 
@@ -279,7 +314,7 @@ print("a")
       })
       vim.cmd.edit({ args = { "tests/testfile.txt" } })
       vim.api.nvim_buf_set_lines(0, 0, -1, true, { "hello" })
-      test_util.set_formatter_output({ "goodbye" })
+      set_formatter_output({ "goodbye" })
       vim.cmd.write()
       local lines = vim.api.nvim_buf_get_lines(0, 0, -1, false)
       vim.fn.delete("tests/testfile.txt")

--- a/tests/test_util.lua
+++ b/tests/test_util.lua
@@ -3,8 +3,6 @@ local conform = require("conform")
 local log = require("conform.log")
 local M = {}
 
-local OUTPUT_FILE = "tests/fake_formatter_output"
-
 M.reset_editor = function()
   vim.cmd.tabonly({ mods = { silent = true } })
   for i, winid in ipairs(vim.api.nvim_tabpage_list_wins(0)) do
@@ -19,21 +17,8 @@ M.reset_editor = function()
   conform.formatters = {}
   conform.formatters_by_ft = {}
   pcall(vim.api.nvim_del_augroup_by_name, "Conform")
-  if vim.fn.filereadable(OUTPUT_FILE) == 1 then
-    vim.fn.delete(OUTPUT_FILE)
-  end
   log.level = vim.log.levels.ERROR
   log.set_handler(print)
-end
-
----@param lines string[]
-M.set_formatter_output = function(lines)
-  local content = table.concat(lines, "\n")
-  local fd = assert(vim.loop.fs_open(OUTPUT_FILE, "w", 420)) -- 0644
-  vim.loop.fs_write(fd, content)
-  -- Make sure we add the final newline
-  vim.loop.fs_write(fd, "\n")
-  vim.loop.fs_close(fd)
 end
 
 return M


### PR DESCRIPTION
closes #224
closes #207
closes #229

Adds tests for the injected formatter, fixes some flappy tests, and adds support for injections that happen in the middle of a line.