### PR TITLE
Fix(black): formatting excluded files results in blank buffer (#249)

### DIFF
--- a/lua/conform/runner.lua
+++ b/lua/conform/runner.lua
@@ -172,7 +172,7 @@ M.apply_format = function(bufnr, original_lines, new_lines, range, only_apply_ra
   -- Abort if output is empty but input is not (i.e. has some non-whitespace characters).
   -- This is to hack around oddly behaving formatters (e.g black outputs nothing for excluded files).
   if new_text:match("^%s*$") and not original_text:match("^%s*$") then
-    log.trace("Aborting because a formatter returned empty output")
+    log.warn("Aborting because a formatter returned empty output for buffer %s", bufname)
     return
   end
 

--- a/lua/conform/runner.lua
+++ b/lua/conform/runner.lua
@@ -171,7 +171,7 @@ M.apply_format = function(bufnr, original_lines, new_lines, range, only_apply_ra
 
   -- Abort if output is empty but input is not (i.e. has some non-whitespace characters).
   -- This is to hack around oddly behaving formatters (e.g black outputs nothing for excluded files).
-  if new_text:match("^%s*$") and not original_text:match('^%s*$') then
+  if new_text:match("^%s*$") and not original_text:match("^%s*$") then
     log.trace("Aborting because a formatter returned empty output")
     return
   end

--- a/lua/conform/runner.lua
+++ b/lua/conform/runner.lua
@@ -169,6 +169,13 @@ M.apply_format = function(bufnr, original_lines, new_lines, range, only_apply_ra
   table.remove(original_lines)
   table.remove(new_lines)
 
+  -- Abort if output is empty but input is not (i.e. has some non-whitespace characters).
+  -- This is to hack around oddly behaving formatters (e.g black outputs nothing for excluded files).
+  if new_text:match("^%s*$") and not original_text:match('^%s*$') then
+    log.trace("Aborting because a formatter returned empty output")
+    return
+  end
+
   log.trace("Comparing lines %s and %s", original_lines, new_lines)
   local indices = vim.diff(original_text, new_text, {
     result_type = "indices",

--- a/tests/fuzzer_spec.lua
+++ b/tests/fuzzer_spec.lua
@@ -97,6 +97,7 @@ describe("fuzzer", function()
   end
 
   local function make_edits(lines)
+    local was_empty = table.concat(lines):match("^%s*$")
     lines = vim.deepcopy(lines)
     for _ = 1, math.random(0, 3) do
       do_insert(lines)
@@ -106,6 +107,12 @@ describe("fuzzer", function()
     end
     for _ = 1, math.random(0, 3) do
       do_delete(lines)
+    end
+    -- avoid blank output (whitepsace only) which is ignored when applying formatting
+    if not was_empty then
+      while table.concat(lines):match("^%s*$") do
+        do_replace(lines)
+      end
     end
     return lines
   end

--- a/tests/runner_spec.lua
+++ b/tests/runner_spec.lua
@@ -272,7 +272,7 @@ print("a")
       assert.are.same({ "newcontent" }, vim.api.nvim_buf_get_lines(0, 0, -1, false))
     end)
 
-    it("discards formatting changes if formatter output is empty and original text is not", function()
+    it("discards formatting changes if formatter output is empty /w non-empty input", function()
       local bufnr = vim.fn.bufadd("testfile")
       vim.fn.bufload(bufnr)
       vim.api.nvim_set_current_buf(bufnr)

--- a/tests/runner_spec.lua
+++ b/tests/runner_spec.lua
@@ -272,6 +272,19 @@ print("a")
       assert.are.same({ "newcontent" }, vim.api.nvim_buf_get_lines(0, 0, -1, false))
     end)
 
+    it("discards formatting changes if formatter output is empty and original text is not", function()
+      local bufnr = vim.fn.bufadd("testfile")
+      vim.fn.bufload(bufnr)
+      vim.api.nvim_set_current_buf(bufnr)
+      local original_lines = { "line one", "line two" }
+      vim.api.nvim_buf_set_lines(bufnr, 0, -1, true, original_lines)
+      vim.bo[bufnr].modified = false
+      test_util.set_formatter_output({ "" })
+      conform.format({ formatters = { "test" }, quiet = true })
+      local output_lines = vim.api.nvim_buf_get_lines(0, 0, -1, false)
+      assert.are.same(original_lines, output_lines)
+    end)
+
     it("formats on save", function()
       conform.setup({
         formatters_by_ft = { ["*"] = { "test" } },

--- a/tests/runner_spec.lua
+++ b/tests/runner_spec.lua
@@ -314,7 +314,7 @@ print("a")
       local original_lines = { "line one", "line two" }
       vim.api.nvim_buf_set_lines(bufnr, 0, -1, true, original_lines)
       vim.bo[bufnr].modified = false
-      test_util.set_formatter_output({ "" })
+      set_formatter_output({ "" })
       conform.format({ formatters = { "test" }, quiet = true })
       local output_lines = vim.api.nvim_buf_get_lines(0, 0, -1, false)
       assert.are.same(original_lines, output_lines)


### PR DESCRIPTION
Fixes #249 

This fix checks for blank formatter output in `apply_format`. Not sure if this is the best place to apply this fix, but seemed  the most obvious place since it'll work the same for both sync and async formats