### PR TITLE
feat: add definition for LuaFormatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,7 @@ You can view this list in vim with `:help conform-formatters`
 - [just](https://github.com/casey/just) - Format Justfile.
 - [ktlint](https://ktlint.github.io/) - An anti-bikeshedding Kotlin linter with built-in formatter.
 - [latexindent](https://github.com/cmhughes/latexindent.pl) - A perl script for formatting LaTeX files that is generally included in major TeX distributions.
+- [luaformatter](https://github.com/Koihik/LuaFormatter) - Reformats your Lua source code.
 - [markdown-toc](https://github.com/jonschlinkert/markdown-toc) - API and CLI for generating a markdown TOC (table of contents) for a README or any markdown files.
 - [markdownlint](https://github.com/DavidAnson/markdownlint) - A Node.js style checker and lint tool for Markdown/CommonMark files.
 - [markdownlint-cli2](https://github.com/DavidAnson/markdownlint-cli2) - A fast, flexible, configuration-based command-line interface for linting Markdown/CommonMark files with the markdownlint library.

--- a/doc/conform.txt
+++ b/doc/conform.txt
@@ -249,6 +249,7 @@ FORMATTERS                                                    *conform-formatter
 `ktlint` - An anti-bikeshedding Kotlin linter with built-in formatter.
 `latexindent` - A perl script for formatting LaTeX files that is generally
               included in major TeX distributions.
+`luaformatter` - Reformats your Lua source code.
 `markdown-toc` - API and CLI for generating a markdown TOC (table of contents)
                for a README or any markdown files.
 `markdownlint` - A Node.js style checker and lint tool for Markdown/CommonMark

--- a/lua/conform/formatters/luaformatter.lua
+++ b/lua/conform/formatters/luaformatter.lua
@@ -1,0 +1,13 @@
+---@type conform.FileFormatterConfig
+return {
+  meta = {
+    url = "https://github.com/Koihik/LuaFormatter",
+    description = "Reformats your Lua source code.",
+  },
+  command = "lua-format",
+  args = { "-i", "$FILENAME" },
+  stdin = false,
+  cwd = require("conform.util").root_file({
+    ".lua-format",
+  }),
+}


### PR DESCRIPTION
This adds [LuaFormatter](https://github.com/Koihik/LuaFormatter) as a formatter for lua. As far as I can tell, it doesn't support stdin/stdout (passing an argument of `-` attempts to format a literal file named `-`). The `-i` argument makes it apply changes in-place instead of returning them on stdout.