### PR TITLE
feat: add xmllint formatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,6 +286,7 @@ You can view this list in vim with `:help conform-formatters`
 - [uncrustify](https://github.com/uncrustify/uncrustify) - A source code beautifier for C, C++, C#, ObjectiveC, D, Java, Pawn and Vala.
 - [usort](https://github.com/facebook/usort) - Safe, minimal import sorting for Python projects.
 - [xmlformat](https://github.com/pamoller/xmlformatter) - xmlformatter is an Open Source Python package, which provides formatting of XML documents.
+- [xmllint](http://xmlsoft.org/xmllint.html) - Despite the name, xmllint can be used to format XML files as well as lint them, and that's the mode this formatter is using.
 - [yamlfix](https://github.com/lyz-code/yamlfix) - A configurable YAML formatter that keeps comments.
 - [yamlfmt](https://github.com/google/yamlfmt) - yamlfmt is an extensible command line tool or library to format yaml files.
 - [yapf](https://github.com/google/yapf) - Yet Another Python Formatter.

--- a/doc/conform.txt
+++ b/doc/conform.txt
@@ -326,6 +326,8 @@ FORMATTERS                                                    *conform-formatter
 `usort` - Safe, minimal import sorting for Python projects.
 `xmlformat` - xmlformatter is an Open Source Python package, which provides
             formatting of XML documents.
+`xmllint` - Despite the name, xmllint can be used to format XML files as well as
+          lint them, and that's the mode this formatter is using.
 `yamlfix` - A configurable YAML formatter that keeps comments.
 `yamlfmt` - yamlfmt is an extensible command line tool or library to format yaml
           files.

--- a/lua/conform/formatters/xmllint.lua
+++ b/lua/conform/formatters/xmllint.lua
@@ -1,0 +1,9 @@
+---@type conform.FileFormatterConfig
+return {
+  meta = {
+    url = "http://xmlsoft.org/xmllint.html",
+    description = "Despite the name, xmllint can be used to format XML files as well as lint them, and that's the mode this formatter is using.",
+  },
+  command = "xmllint",
+  args = { "--format", "-" },
+}

--- a/lua/conform/formatters/xmllint.lua
+++ b/lua/conform/formatters/xmllint.lua
@@ -2,7 +2,7 @@
 return {
   meta = {
     url = "http://xmlsoft.org/xmllint.html",
-    description = "Despite the name, xmllint can be used to format XML files as well as lint them, and that's the mode this formatter is using.",
+    description = "Despite the name, xmllint can be used to format XML files as well as lint them.",
   },
   command = "xmllint",
   args = { "--format", "-" },


### PR DESCRIPTION
Add a config for [xmllint](http://xmlsoft.org/xmllint.html) inspired by [none-ls](https://github.com/nvimtools/none-ls.nvim). 

Source: https://github.com/nvimtools/none-ls.nvim/blob/main/lua/null-ls/builtins/formatting/xmllint.lua