### PR TITLE
fix: set a cwd for dprint

### DIFF
--- a/lua/conform/formatters/dprint.lua
+++ b/lua/conform/formatters/dprint.lua
@@ -1,3 +1,4 @@
+local util = require("conform.util")
 ---@type conform.FileFormatterConfig
 return {
   meta = {
@@ -6,4 +7,10 @@ return {
   },
   command = "dprint",
   args = { "fmt", "--stdin", "$FILENAME" },
+  cwd = util.root_file({
+    "dprint.json",
+    ".dprint.json",
+    "dprint.jsonc",
+    ".dprint.jsonc",
+  }),
 }


### PR DESCRIPTION
The `dprint` cwd according to the docs:

> After [installing](https://dprint.dev/install), the main part of getting setup is to create a dprint.json/dprint.jsonc, or hidden .dprint.json/.dprint.jsonc file in your project.
> https://dprint.dev/setup/

I can confirm it has been tested on my local machine.
