### PR TITLE
fix: set a cwd for djlint

### DIFF
--- a/lua/conform/formatters/djlint.lua
+++ b/lua/conform/formatters/djlint.lua
@@ -1,3 +1,4 @@
+local util = require("conform.util")
 ---@type conform.FileFormatterConfig
 return {
   meta = {
@@ -9,4 +10,7 @@ return {
     "--reformat",
     "-",
   },
+  cwd = util.root_file({
+    ".djlintrc",
+  }),
 }


### PR DESCRIPTION
According to the docs:

> Configuration is done either through your projects pyproject.toml file, or a .djlintrc file.
> https://www.djlint.com/docs/configuration/