### PR TITLE
fix: set a cwd for biome

### DIFF
--- a/lua/conform/formatters/biome.lua
+++ b/lua/conform/formatters/biome.lua
@@ -8,4 +8,7 @@ return {
   command = util.from_node_modules("biome"),
   stdin = true,
   args = { "format", "--stdin-file-path", "$FILENAME" },
+  cwd = util.root_file({
+    "biome.json",
+  }),
 }


### PR DESCRIPTION
According to the docs:

> The Biome configuration file is named `biome.json` and should be placed in the root directory of your project. The root directory is usually the directory containing your project’s `package.json`.

https://biomejs.dev/guides/how-biome-works/#configuration