### PR TITLE
fix: `swift_format` doesn't respect `.swift-format` file

### DIFF
--- a/lua/conform/formatters/swift_format.lua
+++ b/lua/conform/formatters/swift_format.lua
@@ -5,4 +5,6 @@ return {
     description = "Swift formatter from apple. Requires building from source with `swift build`.",
   },
   command = "swift-format",
+  args = { "$FILENAME", "--in-place" },
+  stdin = false,
 }


### PR DESCRIPTION
`swift-format` won't pick up `.swift-format` config file in stdin mode. We need to set `stdin = false` and `--in-place` to make it work with `conform.nvim`.

[apple/swift-format/README.md](https://github.com/apple/swift-format/blob/e312ede68bd8549381f9e2edfef7e6c176e9a50e/README.md#L129-L131)

> *   `-i/--in-place`: Overwrites the input files when formatting instead of
    printing the results to standard output. _No backup of the original file is
    made before it is overwritten._

Fix https://github.com/stevearc/conform.nvim/issues/211