### PR TITLE
feat: add biome-check formatter

### DIFF
--- a/lua/conform/formatters/biome-check.lua
+++ b/lua/conform/formatters/biome-check.lua
@@ -1,0 +1,14 @@
+local util = require("conform.util")
+---@type conform.FileFormatterConfig
+return {
+  meta = {
+    url = "https://github.com/biomejs/biome",
+    description = "A toolchain for web projects, aimed to provide functionalities to maintain them.",
+  },
+  command = util.from_node_modules("biome"),
+  stdin = true,
+  args = { "check", "--apply-unsafe", "--stdin-file-path", "$FILENAME" },
+  cwd = util.root_file({
+    "biome.json",
+  }),
+}


### PR DESCRIPTION
`biome` formatter uses `biome format` command which applies formatting but doesn't apply lint autofixes. Couldn't find a better way then to create another formatter that uses `biome check --apply-unsafe`