### PR TITLE
feat(formatters): add eslint formatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ You can view this list in vim with `:help conform-formatters`
 - [easy-coding-standard](https://github.com/easy-coding-standard/easy-coding-standard) - ecs - Use Coding Standard with 0-knowledge of PHP-CS-Fixer and PHP_CodeSniffer.
 - [elm_format](https://github.com/avh4/elm-format) - elm-format formats Elm source code according to a standard set of rules based on the official [Elm Style Guide](https://elm-lang.org/docs/style-guide).
 - [erb_format](https://github.com/nebulab/erb-formatter) - Format ERB files with speed and precision.
+- [eslint](https://github.com/eslint/eslint) - A tool for identifying and reporting on patterns found in ECMAScript/JavaScript code
 - [eslint_d](https://github.com/mantoni/eslint_d.js/) - Like ESLint, but faster.
 - [fish_indent](https://fishshell.com/docs/current/cmds/fish_indent.html) - Indent or otherwise prettify a piece of fish code.
 - [fixjson](https://github.com/rhysd/fixjson) - JSON Fixer for Humans using (relaxed) JSON5.

--- a/doc/conform.txt
+++ b/doc/conform.txt
@@ -223,6 +223,7 @@ FORMATTERS                                                    *conform-formatter
              rules based on the official [Elm Style Guide](https://elm-
              lang.org/docs/style-guide).
 `erb_format` - Format ERB files with speed and precision.
+eslint - Format Typescript and Javascript files.
 `eslint_d` - Like ESLint, but faster.
 `fish_indent` - Indent or otherwise prettify a piece of fish code.
 `fixjson` - JSON Fixer for Humans using (relaxed) JSON5.

--- a/doc/conform.txt
+++ b/doc/conform.txt
@@ -223,7 +223,7 @@ FORMATTERS                                                    *conform-formatter
              rules based on the official [Elm Style Guide](https://elm-
              lang.org/docs/style-guide).
 `erb_format` - Format ERB files with speed and precision.
-eslint - Format Typescript and Javascript files.
+`eslint` - Format Typescript and Javascript files.
 `eslint_d` - Like ESLint, but faster.
 `fish_indent` - Indent or otherwise prettify a piece of fish code.
 `fixjson` - JSON Fixer for Humans using (relaxed) JSON5.

--- a/lua/conform/formatters/eslint.lua
+++ b/lua/conform/formatters/eslint.lua
@@ -1,0 +1,13 @@
+local util = require("conform.util")
+---@type conform.FileFormatterConfig
+return {
+  meta = {
+    url = "https://github.com/eslint/eslint",
+    description = "A tool for identifying and reporting on patterns found in ECMAScript/JavaScript code",
+  },
+  command = util.from_node_modules("eslint"),
+  args = { "--fix-to-stdout", "--stdin", "--stdin-filename", "$FILENAME" },
+  cwd = util.root_file({
+    "package.json",
+  }),
+}


### PR DESCRIPTION
Added ESLint, because not all people use eslint_d.

In this case, the arguments that must be passed to eslint are exactly the same as in eslint_d, so there should be no problems.