### PR TITLE
Add configuration for `gersemi`

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,7 @@ You can view this list in vim with `:help conform-formatters`
 - [fourmolu](https://hackage.haskell.org/package/fourmolu) - Fourmolu is a formatter for Haskell source code.
 - [gci](https://github.com/daixiang0/gci) - GCI, a tool that controls Go package import order and makes it always deterministic.
 - [gdformat](https://github.com/Scony/godot-gdscript-toolkit) - A formatter for Godot's gdscript.
+- [gersemi](https://github.com/BlankSpruce/gersemi) - A formatter to make your CMake code the real treasure.
 - [gn](https://gn.googlesource.com/gn/) - gn build system.
 - [gofmt](https://pkg.go.dev/cmd/gofmt) - Formats go programs.
 - [gofumpt](https://github.com/mvdan/gofumpt) - Enforce a stricter format than gofmt, while being backwards compatible. That is, gofumpt is happy with a subset of the formats that gofmt is happy with.

--- a/lua/conform/formatters/gersemi.lua
+++ b/lua/conform/formatters/gersemi.lua
@@ -1,0 +1,11 @@
+local util = require("conform.util")
+---@type conform.FileFormatterConfig
+return {
+  meta = {
+    url = "https://github.com/BlankSpruce/gersemi",
+    description = "A formatter to make your CMake code the real treasure.",
+  },
+  command = "gersemi",
+  args = { "--quiet", "-" },
+  cwd = util.root_file({ ".gersemirc" }),
+}


### PR DESCRIPTION
Since `cmake_format` has seemingly been completely abandoned, this would be great to have pre-configured. 