### PR TITLE
prettierd: presence of package.json is insufficient for deciding if prettierd should attach

### DIFF
--- a/lua/conform/formatters/prettierd.lua
+++ b/lua/conform/formatters/prettierd.lua
@@ -22,7 +22,6 @@ return {
     ".prettierrc.cjs",
     ".prettierrc.toml",
     "prettier.config.js",
-    "prettier.config.cjs",
-    "package.json",
+    "prettier.config.cjs"
   }),
 }


### PR DESCRIPTION
May help with: https://github.com/stevearc/conform.nvim/issues/268

the only question we can ask if prettier should be enable is if there is a prettier config file