### PR TITLE
Allow rust async code to be formatted by rustfmt

### DIFF
--- a/lua/conform/formatters/rustfmt.lua
+++ b/lua/conform/formatters/rustfmt.lua
@@ -5,5 +5,5 @@ return {
     description = "A tool for formatting rust code according to style guidelines.",
   },
   command = "rustfmt",
-  args = { "--emit=stdout" },
+  args = { "--emit=stdout", "--edition=2021" },
 }


### PR DESCRIPTION
Hello,

This allows rust async code to be formatted with rustfmt.

closes #320 