### PR TITLE
fix(prettier): Buffer range formatting

### DIFF
--- a/lua/conform/formatters/prettier.lua
+++ b/lua/conform/formatters/prettier.lua
@@ -57,7 +57,7 @@ return {
   end,
   range_args = function(self, ctx)
     local start_offset, end_offset = util.get_offsets_from_range(ctx.buf, ctx.range)
-    local args = eval_parser(self, ctx) or { "$FILENAME" }
+    local args = eval_parser(self, ctx) or { "--stdin-filepath", "$FILENAME" }
     return vim.list_extend(args, { "--range-start=" .. start_offset, "--range-end=" .. end_offset })
   end,
   cwd = util.root_file({


### PR DESCRIPTION
Currently we provide a filename, which means prettier will format the given file and not what we feed via stdin.