### PR TITLE
fix: add cwd to honor project php-cs-fixer

### DIFF
--- a/lua/conform/formatters/php_cs_fixer.lua
+++ b/lua/conform/formatters/php_cs_fixer.lua
@@ -12,4 +12,5 @@ return {
   }, "php-cs-fixer"),
   args = { "fix", "$FILENAME" },
   stdin = false,
+  cwd = util.root_file({ "composer.json" }),
 }


### PR DESCRIPTION
This adds the `cwd` option into the default php-cs-fixer options in order to honor project-level configuration.

`composer.json` should be the "safest" project root option here, since if a project doesn't have a `.php-cs-fixer.dist.php` or similar config file, it looks like we may accidentally use a parent config instead of the default config (currently used with these conform settings), which I believe would be different than typical php-cs-fixer behavior (i.e. use project-level config, or default)