### PR TITLE
[2/2] fix(phpcbf): use non-stdin formatting and customize tempfile name

### DIFF
--- a/lua/conform/formatters/phpcbf.lua
+++ b/lua/conform/formatters/phpcbf.lua
@@ -9,10 +9,10 @@ return {
   command = util.find_executable({
     "vendor/bin/phpcbf",
   }, "phpcbf"),
-  args = function(self, ctx)
-    return { "-q", "--stdin-path=" .. ctx.filename, "-" }
-  end,
-  stdin = true,
+  args = { "$FILENAME" },
+  stdin = false,
+  -- phpcbf ignores hidden files, so we have to override the default here
+  tmpfile_format = "conform.$RANDOM.$FILENAME",
   -- 0: no errors found
   -- 1: errors found
   -- 2: fixable errors found


### PR DESCRIPTION
|   |  PR  |                               Title                                |
| - | ---- | ------------------------------------------------------------------ |
| 1 | #332 | feat: add formatter config option to change name of temporary file |
| 2 | >333 | fix(phpcbf): use non-stdin formatting and customize tempfile name  |

fixes #289