### PR TITLE
Remove --force flag in sqlfluff since it's default now

### DIFF
--- a/lua/conform/formatters/sqlfluff.lua
+++ b/lua/conform/formatters/sqlfluff.lua
@@ -7,7 +7,7 @@ return {
     description = "A modular SQL linter and auto-formatter with support for multiple dialects and templated code.",
   },
   command = "sqlfluff",
-  args = { "fix", "--force", "--dialect=ansi", "-" },
+  args = { "fix", "--dialect=ansi", "-" },
   stdin = true,
   cwd = util.root_file({
     ".sqlfluff",


### PR DESCRIPTION
Otherwise we get the following error `The -f/--force option is deprecated as it is now the default behaviour.`