### PR TITLE
fix: use `--force-exclude` with Ruff

### DIFF
--- a/lua/conform/formatters/ruff_fix.lua
+++ b/lua/conform/formatters/ruff_fix.lua
@@ -1,14 +1,16 @@
 ---@type conform.FileFormatterConfig
 return {
   meta = {
-    url = "https://beta.ruff.rs/docs/",
+    url = "https://docs.astral.sh/ruff/",
     description = "An extremely fast Python linter, written in Rust. Fix lint errors.",
   },
   command = "ruff",
   args = {
+    "check",
     "--fix",
-    "-e",
-    "-n",
+    "--force-exclude",
+    "--exit-zero",
+    "--no-cache",
     "--stdin-filename",
     "$FILENAME",
     "-",
@@ -17,5 +19,6 @@ return {
   cwd = require("conform.util").root_file({
     "pyproject.toml",
     "ruff.toml",
+    ".ruff.toml",
   }),
 }

--- a/lua/conform/formatters/ruff_format.lua
+++ b/lua/conform/formatters/ruff_format.lua
@@ -1,12 +1,13 @@
 ---@type conform.FileFormatterConfig
 return {
   meta = {
-    url = "https://beta.ruff.rs/docs/",
+    url = "https://docs.astral.sh/ruff/",
     description = "An extremely fast Python linter, written in Rust. Formatter subcommand.",
   },
   command = "ruff",
   args = {
     "format",
+    "--force-exclude",
     "--stdin-filename",
     "$FILENAME",
     "-",
@@ -15,5 +16,6 @@ return {
   cwd = require("conform.util").root_file({
     "pyproject.toml",
     "ruff.toml",
+    ".ruff.toml",
   }),
 }


### PR DESCRIPTION
Hi 👋, thank you for this plugin!

This PR updates the arguments passed to Ruff to include `--force-exclude` to make exclusions work. To give some context, if the `ruff` command is invoked with a filename directly then the exclusions from the config file aren't taken into consideration. When `--force-exclude` is passed, only then it's used to determine whether to skip running `ruff` on the given file or not.

From the CLI help menu:

```
File selection:
      --exclude <FILE_PATTERN>
          List of paths, used to omit files and/or directories from analysis

      --force-exclude
          Enforce exclusions, even for paths passed to Ruff directly on the
          command-line. Use `--no-force-exclude` to disable
```

We also use the same when invoking the `ruff` command via the LSP implementation:
1. Reference to `ruff check` command args: https://github.com/astral-sh/ruff-lsp/blob/145e36dbe62b80f0a5682f25782a7038da9a8621/ruff_lsp/server.py#L158
2. Reference to `ruff format` command args: https://github.com/astral-sh/ruff-lsp/blob/145e36dbe62b80f0a5682f25782a7038da9a8621/ruff_lsp/server.py#L1918

In addition to that, the following changes were made:
1. Update the documentation link
2. Use full command-line arguments as it reads better
3. Use the include the `check` subcommand as calling `ruff` via an implicit check command is now deprecated
4. Include `.ruff.toml` file to determine the current working directory
