### PR TITLE
Add formatter for Inko

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,7 @@ You can view this list in vim with `:help conform-formatters`
 - [htmlbeautifier](https://github.com/threedaymonk/htmlbeautifier) - A normaliser/beautifier for HTML that also understands embedded Ruby. Ideal for tidying up Rails templates.
 - [indent](https://www.gnu.org/software/indent/) - GNU Indent.
 - [injected](doc/advanced_topics.md#injected-language-formatting-code-blocks) - Format treesitter injected languages.
+- [inko](https://inko-lang.org/) - A language for building concurrent software with confidence.
 - [isort](https://github.com/PyCQA/isort) - Python utility / library to sort imports alphabetically and automatically separate them into sections and by type.
 - [joker](https://github.com/candid82/joker) - Small Clojure interpreter, linter and formatter.
 - [jq](https://github.com/stedolan/jq) - Command-line JSON processor.

--- a/doc/conform.txt
+++ b/doc/conform.txt
@@ -253,6 +253,7 @@ FORMATTERS                                                    *conform-formatter
                  embedded Ruby. Ideal for tidying up Rails templates.
 `indent` - GNU Indent.
 `injected` - Format treesitter injected languages.
+`inko` - A language for building concurrent software with confidence.
 `isort` - Python utility / library to sort imports alphabetically and
         automatically separate them into sections and by type.
 `joker` - Small Clojure interpreter, linter and formatter.

--- a/lua/conform/formatters/inko.lua
+++ b/lua/conform/formatters/inko.lua
@@ -1,0 +1,9 @@
+---@type conform.FileFormatterConfig
+return {
+  meta = {
+    url = "https://inko-lang.org/",
+    description = "A language for building concurrent software with confidence",
+  },
+  command = "inko",
+  args = { "fmt", "-" },
+}


### PR DESCRIPTION
This adds support for formatting Inko (https://inko-lang.org/) source files using the `inko fmt` command.