### PR TITLE
refactor: Rename clang_format to clang-format

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ You can view this list in vim with `:help conform-formatters`
 - [buildifier](https://github.com/bazelbuild/buildtools/tree/master/buildifier) - buildifier is a tool for formatting bazel BUILD and .bzl files with a standard convention.
 - [cabal_fmt](https://hackage.haskell.org/package/cabal-fmt) - Format cabal files with cabal-fmt
 - [cbfmt](https://github.com/lukas-reineke/cbfmt) - A tool to format codeblocks inside markdown and org documents.
-- [clang_format](https://www.kernel.org/doc/html/latest/process/clang-format.html) - Tool to format C/C++/… code according to a set of rules and heuristics.
+- [clang-format](https://www.kernel.org/doc/html/latest/process/clang-format.html) - Tool to format C/C++/… code according to a set of rules and heuristics.
 - [cljstyle](https://github.com/greglook/cljstyle) - Formatter for Clojure code.
 - [cmake_format](https://github.com/cheshirekow/cmake_format) - Parse cmake listfiles and format them nicely.
 - [codespell](https://github.com/codespell-project/codespell) - Check code for common misspellings.

--- a/doc/conform.txt
+++ b/doc/conform.txt
@@ -203,7 +203,7 @@ FORMATTERS                                                    *conform-formatter
              with a standard convention.
 `cabal_fmt` - Format cabal files with cabal-fmt
 `cbfmt` - A tool to format codeblocks inside markdown and org documents.
-`clang_format` - Tool to format C/C++/… code according to a set of rules and
+`clang-format` - Tool to format C/C++/… code according to a set of rules and
                heuristics.
 `cljstyle` - Formatter for Clojure code.
 `cmake_format` - Parse cmake listfiles and format them nicely.

--- a/lua/conform/formatters/clang-format.lua
+++ b/lua/conform/formatters/clang-format.lua
@@ -1,0 +1,22 @@
+local util = require("conform.util")
+---@type conform.FileFormatterConfig
+return {
+  meta = {
+    url = "https://www.kernel.org/doc/html/latest/process/clang-format.html",
+    description = "Tool to format C/C++/… code according to a set of rules and heuristics.",
+  },
+  command = "clang-format",
+  args = { "-assume-filename", "$FILENAME" },
+  range_args = function(self, ctx)
+    local start_offset, end_offset = util.get_offsets_from_range(ctx.buf, ctx.range)
+    local length = end_offset - start_offset
+    return {
+      "-assume-filename",
+      "$FILENAME",
+      "--offset",
+      tostring(start_offset),
+      "--length",
+      tostring(length),
+    }
+  end,
+}

--- a/lua/conform/formatters/clang_format.lua
+++ b/lua/conform/formatters/clang_format.lua
@@ -1,22 +1,4 @@
-local util = require("conform.util")
----@type conform.FileFormatterConfig
-return {
-  meta = {
-    url = "https://www.kernel.org/doc/html/latest/process/clang-format.html",
-    description = "Tool to format C/C++/… code according to a set of rules and heuristics.",
-  },
-  command = "clang-format",
-  args = { "-assume-filename", "$FILENAME" },
-  range_args = function(self, ctx)
-    local start_offset, end_offset = util.get_offsets_from_range(ctx.buf, ctx.range)
-    local length = end_offset - start_offset
-    return {
-      "-assume-filename",
-      "$FILENAME",
-      "--offset",
-      tostring(start_offset),
-      "--length",
-      tostring(length),
-    }
-  end,
-}
+-- This was renamed to clang-format
+local conf = vim.deepcopy(require("conform.formatters.clang-format"))
+conf.meta.deprecated = true
+return conf


### PR DESCRIPTION
## Scope
This makes the formatter name consistent with the executable and also with other tools like e.g. Mason, for better interoperability.

## Why
One use-case is to be able to automatically install formatters that are registered with other tools like Mason.

```lua
local registered_formatters = require("conform").list_all_formatters()
for _, formatter in ipairs(registered_formatters) do
   MasonInstall(formatter) -- Asume a MasonInstall function exists
end
```