### PR TITLE
Add formatter for SML (Standard ML)

### DIFF
--- a/lua/conform/formatters/smlfmt.lua
+++ b/lua/conform/formatters/smlfmt.lua
@@ -1,0 +1,8 @@
+---@type conform.FileFormatterConfig
+return {
+  meta = {
+    url = "https://github.com/shwestrick/smlfmt",
+    description = "A custom parser and code formatter for Standard ML.",
+  },
+  command = "smlfmt",
+}


### PR DESCRIPTION
This PR adds formatter support for [SML](https://www.smlnj.org/) using `smlfmt` (https://github.com/shwestrick/smlfmt).