### PR TITLE
Do not output colors in terraform_fmt

### DIFF
--- a/lua/conform/formatters/terraform_fmt.lua
+++ b/lua/conform/formatters/terraform_fmt.lua
@@ -5,5 +5,5 @@ return {
     description = "The terraform-fmt command rewrites `terraform` configuration files to a canonical format and style.",
   },
   command = "terraform",
-  args = { "fmt", "-" },
+  args = { "fmt", "-no-color", "-" },
 }


### PR DESCRIPTION
Currently the `terraform_fmt` formatter outputs colors, resulting in "bad" characters in conform.log.

Example:
```
22:03:46[ERROR] Formatter 'terraform_fmt' error: [31m[31m╷[0m[0m
[31m│[0m [0m[1m[31mError: [0m[0m[1mAttribute redefined[0m
[31m│[0m [0m
[31m│[0m [0m[0m  on <stdin> line 3, in resource "test":
[31m│[0m [0m   3: 	[4mhello[0m = 123[0m
[31m│[0m [0m
[31m│[0m [0mThe argument "hello" was already set at <stdin>:2,3-8. Each argument may be
[31m│[0m [0mset only once.
[31m╵[0m[0m
[0m[0m
```

Adding the `-no-color` argument to `terraform fmt` will result in a more readable output:
```
22:13:44[ERROR] Formatter 'terraform_fmt' error: 
Error: Attribute redefined

  on <stdin> line 3, in resource "test":
   3: 	hello = 123

The argument "hello" was already set at <stdin>:2,3-8. Each argument may be
set only once.
```

I know this can be added via config, but IMO this should be the default behaviour.