### PR TITLE
fix(biome-check): use safe fixes

### DIFF
--- a/lua/conform/formatters/biome-check.lua
+++ b/lua/conform/formatters/biome-check.lua
@@ -7,7 +7,7 @@ return {
   },
   command = util.from_node_modules("biome"),
   stdin = true,
-  args = { "check", "--apply-unsafe", "--stdin-file-path", "$FILENAME" },
+  args = { "check", "--apply", "--stdin-file-path", "$FILENAME" },
   cwd = util.root_file({
     "biome.json",
   }),


### PR DESCRIPTION
This PR updates the **biome-check** formatter. The modification changes the default behavior from using unsafe code fix mode to safe code fix mode to enhance reliability and security when auto-correcting code. 

More details about the tool can be found at [biomejs.dev/linter](https://biomejs.dev/linter/).