### PR TITLE
Correctly find prettierd executable on windows

### DIFF
--- a/lua/conform/formatters/prettierd.lua
+++ b/lua/conform/formatters/prettierd.lua
@@ -1,3 +1,4 @@
+local fs = require("conform.fs")
 local util = require("conform.util")
 ---@type conform.FileFormatterConfig
 return {
@@ -5,7 +6,7 @@ return {
     url = "https://github.com/fsouza/prettierd",
     description = "prettier, as a daemon, for ludicrous formatting speed.",
   },
-  command = util.from_node_modules("prettierd"),
+  command = util.from_node_modules(fs.is_windows and "prettierd.cmd" or "prettierd"),
   args = { "$FILENAME" },
   range_args = function(self, ctx)
     local start_offset, end_offset = util.get_offsets_from_range(ctx.buf, ctx.range)


### PR DESCRIPTION
When formatting with `prettierd` on windows, even though the executable exists, there is the following error:

```
19:50:56[ERROR] Formatter 'prettierd' error in jobstart: Vim:E903: Process failed to start: no such file or directory: "C:/Users/myuser/mytest/node_modules/.bin/prettierd"
```



This PR adds detection and selection of `.cmd` executable on windows, the same way we do in `prettier.lua`, which fixes the above.