### PR TITLE
feat: add dos2unix converter script

### DIFF
--- a/lua/conform/formatters/dos2unix.lua
+++ b/lua/conform/formatters/dos2unix.lua
@@ -1,0 +1,12 @@
+local util = require("conform.util")
+---@type conform.FileFormatterConfig
+return {
+  meta = {
+    url = "https://dos2unix.sourceforge.io/",
+    description = "Convert from dos line endings to unix line endings",
+  },
+  command = "dos2unix",
+  args = {
+    "--to-stdout",
+  },
+}

--- a/lua/conform/formatters/dos2unix.lua
+++ b/lua/conform/formatters/dos2unix.lua
@@ -1,4 +1,3 @@
-local util = require("conform.util")
 ---@type conform.FileFormatterConfig
 return {
   meta = {


### PR DESCRIPTION
Add dos2unix formatter.

This is convenient simple formatter that fixes when a formatter (such as isort on windows) changes the line endings of streamed text.