### PR TITLE
Neovim 0.10 Compatible Functions Require a Default

### DIFF
--- a/lua/conform/util.lua
+++ b/lua/conform/util.lua
@@ -135,11 +135,11 @@ M.extend_args = function(args, extra_args, opts)
       end
       local ret = {}
       if opts.append then
-        vim.list_extend(ret, args)
-        vim.list_extend(ret, extra_args)
+        vim.list_extend(ret, args or {})
+        vim.list_extend(ret, extra_args or {})
       else
-        vim.list_extend(ret, extra_args)
-        vim.list_extend(ret, args)
+        vim.list_extend(ret, extra_args or {})
+        vim.list_extend(ret, args or {})
       end
       return ret
     end


### PR DESCRIPTION
Thank you for maintaining this beautiful plugin. With the latest changes I have encountered a tiny bit of error therefore I have opened up this merge request.

It throws errors when the configured formater does not have a default.

```text
   Error  11:10:56 msg_show.lua_error Error detected while processing BufWritePre Autocommands for "*":
11:10:56 msg_show Error executing lua callback: vim/shared.lua:0: src: expected table, got nil
stack traceback:
	[C]: in function 'error'
	vim/shared.lua: in function 'validate'
	vim/shared.lua: in function 'list_extend'
	....local/share/nvim/lazy/conform.nvim/lua/conform/util.lua:142: in function 'computed_args'
	...ocal/share/nvim/lazy/conform.nvim/lua/conform/runner.lua:29: in function 'build_cmd'
	...ocal/share/nvim/lazy/conform.nvim/lua/conform/runner.lua:280: in function 'run_formatter'
	...ocal/share/nvim/lazy/conform.nvim/lua/conform/runner.lua:622: in function 'format_lines_sync'
	...ocal/share/nvim/lazy/conform.nvim/lua/conform/runner.lua:578: in function 'format_sync'
	....local/share/nvim/lazy/conform.nvim/lua/conform/init.lua:451: in function 'format'
	/Users/cenk/.config/nvim/lua/extensions/conform-nvim.lua:85: in function 'format'
	/Users/cenk/.config/nvim/lua/lvim/lsp/format.lua:10: in function </Users/cenk/.config/nvim/lua/lvim/lsp/format.lua:9>
```