### PR TITLE
feat: set mix format --stdin-filename

### DIFF
--- a/lua/conform/formatters/mix.lua
+++ b/lua/conform/formatters/mix.lua
@@ -5,7 +5,7 @@ return {
     description = "Format Elixir files using the mix format command.",
   },
   command = "mix",
-  args = { "format", "-" },
+  args = { "format", "--stdin-filename", "$FILENAME", "-" },
   cwd = require("conform.util").root_file({
     ".formatter.exs",
     "mix.exs",


### PR DESCRIPTION
This is more of a fix than a feature.
By adding the filename to `--stdin-filename`, `mix format` can detect the type of file. By default `--stdin-filename` is `stdin.exs` thus only allowing formatting of Elixir.
This change is needed to allow formatting for `mix format` plugins. Most notably the `heex` template files which are used in the Phoenix Framework, which comes with a `heex` plugin by default. (https://hexdocs.pm/phoenix_live_view/Phoenix.LiveView.HTMLFormatter.html)

The `mix format` behaviour is documented here: https://hexdocs.pm/mix/main/Mix.Tasks.Format.html#module-task-specific-options