### PR TITLE
Add a generic hcl formatter (hclfmt)

### DIFF
--- a/lua/conform/formatters/hcl.lua
+++ b/lua/conform/formatters/hcl.lua
@@ -2,7 +2,7 @@
 return {
   meta = {
     url = "https://github.com/hashicorp/hcl",
-    description = "A formatter for HCL files",
+    description = "A formatter for HCL files.",
   },
   command = "hclfmt",
 }

--- a/lua/conform/formatters/hcl.lua
+++ b/lua/conform/formatters/hcl.lua
@@ -1,0 +1,8 @@
+---@type conform.FileFormatterConfig
+return {
+  meta = {
+    url = "https://github.com/hashicorp/hcl",
+    description = "A formatter for HCL files",
+  },
+  command = "hclfmt",
+}


### PR DESCRIPTION
Adds a generic formatter for `hcl` files.

I realize that there are already 2 formatters for hcl files defined in this repo, but to use either one of them, you need to have the specific tool installed (terraform or packer).

Meant to be used with the `hclfmt` binary that is built from the [hcl project](https://github.com/mason-org/mason-registry/blob/main/packages/hclfmt/package.yaml). This is also the one that can be obtained with mason: [registry link](https://github.com/mason-org/mason-registry/blob/main/packages/hclfmt/package.yaml).

Formats input from stdin and writes to stdout.