### PR TITLE
feat: add support for leptosfmt

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,7 @@ You can view this list in vim with `:help conform-formatters`
 - [ktfmt](https://github.com/facebook/ktfmt) - Reformats Kotlin source code to comply with the common community standard conventions.
 - [ktlint](https://ktlint.github.io/) - An anti-bikeshedding Kotlin linter with built-in formatter.
 - [latexindent](https://github.com/cmhughes/latexindent.pl) - A perl script for formatting LaTeX files that is generally included in major TeX distributions.
+- [leptosfmt](https://github.com/bram209/leptosfmt) - A formatter for the Leptos `view!` macro.
 - [liquidsoap-prettier](https://github.com/savonet/liquidsoap-prettier) - A binary to format Liquidsoap scripts
 - [markdown-toc](https://github.com/jonschlinkert/markdown-toc) - API and CLI for generating a markdown TOC (table of contents) for a README or any markdown files.
 - [markdownlint](https://github.com/DavidAnson/markdownlint) - A Node.js style checker and lint tool for Markdown/CommonMark files.

--- a/doc/conform.txt
+++ b/doc/conform.txt
@@ -270,6 +270,7 @@ FORMATTERS                                                    *conform-formatter
 `ktlint` - An anti-bikeshedding Kotlin linter with built-in formatter.
 `latexindent` - A perl script for formatting LaTeX files that is generally
               included in major TeX distributions.
+`leptosfmt` - A formatter for the Leptos `view!` macro.
 `liquidsoap-prettier` - A binary to format Liquidsoap scripts
 `markdown-toc` - API and CLI for generating a markdown TOC (table of contents)
                for a README or any markdown files.

--- a/lua/conform/formatters/leptosfmt.lua
+++ b/lua/conform/formatters/leptosfmt.lua
@@ -1,0 +1,9 @@
+---@type conform.FileFormatterConfig
+return {
+  meta = {
+    url = "https://github.com/bram209/leptosfmt",
+    description = "A formatter for the Leptos view! macro.",
+  },
+  command = "leptosfmt",
+  args = { "--stdin" },
+}


### PR DESCRIPTION
As title says: this adds support for leptosfmt 😀 

This is not the same as #363 since that suggestion does both leptosfmt and rustfmt combined. This commit just adds a leptos formatter, which can then be chained together sequentially with rustfmt in a conform config, if someone wants to do that.