### PR TITLE
feat: add `ruff_organize_imports` formatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,6 +283,7 @@ You can view this list in vim with `:help conform-formatters`
 - [rubyfmt](https://github.com/fables-tales/rubyfmt) - Ruby Autoformatter! (Written in Rust)
 - [ruff_fix](https://docs.astral.sh/ruff/) - An extremely fast Python linter, written in Rust. Fix lint errors.
 - [ruff_format](https://docs.astral.sh/ruff/) - An extremely fast Python linter, written in Rust. Formatter subcommand.
+- [ruff_organize_imports](https://docs.astral.sh/ruff/) - An extremely fast Python linter, written in Rust. Organize imports.
 - [rufo](https://github.com/ruby-formatter/rufo) - Rufo is an opinionated ruby formatter.
 - [rustfmt](https://github.com/rust-lang/rustfmt) - A tool for formatting rust code according to style guidelines.
 - [rustywind](https://github.com/avencera/rustywind) - A tool for formatting Tailwind CSS classes.

--- a/lua/conform/formatters/ruff_organize_imports.lua
+++ b/lua/conform/formatters/ruff_organize_imports.lua
@@ -1,0 +1,25 @@
+---@type conform.FileFormatterConfig
+return {
+  meta = {
+    url = "https://docs.astral.sh/ruff/",
+    description = "An extremely fast Python linter, written in Rust. Organize imports.",
+  },
+  command = "ruff",
+  args = {
+    "check",
+    "--fix",
+    "--force-exclude",
+    "--select=I001",
+    "--exit-zero",
+    "--no-cache",
+    "--stdin-filename",
+    "$FILENAME",
+    "-",
+  },
+  stdin = true,
+  cwd = require("conform.util").root_file({
+    "pyproject.toml",
+    "ruff.toml",
+    ".ruff.toml",
+  }),
+}


### PR DESCRIPTION
This adds another `ruff` based formatter which tells it to organize imports. Useful for replacing `isort` with ruff. Neither the `ruff_fix` nor `ruff_format` cover this case or include it in their formatting.


Thanks in advance!