### PR TITLE
Account for spaces in the file path when formatting with stylua

### DIFF
--- a/lua/conform/formatters/stylua.lua
+++ b/lua/conform/formatters/stylua.lua
@@ -6,13 +6,13 @@ return {
     description = "An opinionated code formatter for Lua.",
   },
   command = "stylua",
-  args = { "--search-parent-directories", "--stdin-filepath", "$FILENAME", "-" },
+  args = { "--search-parent-directories", "--stdin-filepath", "'$FILENAME'", "-" },
   range_args = function(self, ctx)
     local start_offset, end_offset = util.get_offsets_from_range(ctx.buf, ctx.range)
     return {
       "--search-parent-directories",
       "--stdin-filepath",
-      "$FILENAME",
+      "'$FILENAME'",
       "--range-start",
       tostring(start_offset),
       "--range-end",


### PR DESCRIPTION
Hi,

I found a bug when formatting a file that has spaces in its path using stylua on Windows.
The command that was being executed was something like:
`stylua --search-parent-directories --stdin-filepath C:\\some\\path with\\spaces.lua`
This was causing stylua to search for `C:\\some\\path` and `with\\spaces.lua` as two separate files and crash.
I simply added simple quotes around the $FILENAME environment variable so the executed command would be:
`stylua --search-parent-directories --stdin-filepath 'C:\\some\\path with\\spaces.lua'`

I don't think this should break anything but i didn't do much testing.
Let me know if you want me to look at some particular test cases.