### PR TITLE
fix(dprint): add support node_modules

### DIFF
--- a/lua/conform/formatters/dprint.lua
+++ b/lua/conform/formatters/dprint.lua
@@ -5,7 +5,7 @@ return {
     url = "https://github.com/dprint/dprint",
     description = "Pluggable and configurable code formatting platform written in Rust.",
   },
-  command = "dprint",
+  command = util.from_node_modules("dprint"),
   args = { "fmt", "--stdin", "$FILENAME" },
   cwd = util.root_file({
     "dprint.json",


### PR DESCRIPTION
[Install - dprint - Code Formatter](https://dprint.dev/install/)
[dprint - npm](https://www.npmjs.com/package/dprint)

dprint is supports installation via npm, so I have also included node_modules in the search targets.