### PR TITLE
[feat]: add treesitter query formatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,8 +221,8 @@ You can view this list in vim with `:help conform-formatters`
 - [fish_indent](https://fishshell.com/docs/current/cmds/fish_indent.html) - Indent or otherwise prettify a piece of fish code.
 - [fixjson](https://github.com/rhysd/fixjson) - JSON Fixer for Humans using (relaxed) JSON5.
 - [fnlfmt](https://git.sr.ht/~technomancy/fnlfmt) - A formatter for Fennel code.
-- [format-queries](https://github.com/nvim-treesitter/nvim-treesitter/blob/main/CONTRIBUTING.md#formatting) - Format a Tree-sitter scm (query) file.
 - [forge_fmt](https://github.com/foundry-rs/foundry) - Forge is a command-line tool that ships with Foundry. Forge tests, builds, and deploys your smart contracts.
+- [format-queries](https://github.com/nvim-treesitter/nvim-treesitter/blob/main/CONTRIBUTING.md#formatting) - Tree-sitter query formatter
 - [fourmolu](https://hackage.haskell.org/package/fourmolu) - A fork of ormolu that uses four space indentation and allows arbitrary configuration.
 - [gci](https://github.com/daixiang0/gci) - GCI, a tool that controls Go package import order and makes it always deterministic.
 - [gdformat](https://github.com/Scony/godot-gdscript-toolkit) - A formatter for Godot's gdscript.

--- a/README.md
+++ b/README.md
@@ -221,6 +221,7 @@ You can view this list in vim with `:help conform-formatters`
 - [fish_indent](https://fishshell.com/docs/current/cmds/fish_indent.html) - Indent or otherwise prettify a piece of fish code.
 - [fixjson](https://github.com/rhysd/fixjson) - JSON Fixer for Humans using (relaxed) JSON5.
 - [fnlfmt](https://git.sr.ht/~technomancy/fnlfmt) - A formatter for Fennel code.
+- [format-queries](https://github.com/nvim-treesitter/nvim-treesitter/blob/main/CONTRIBUTING.md#formatting) - Format a Tree-sitter scm (query) file.
 - [forge_fmt](https://github.com/foundry-rs/foundry) - Forge is a command-line tool that ships with Foundry. Forge tests, builds, and deploys your smart contracts.
 - [fourmolu](https://hackage.haskell.org/package/fourmolu) - A fork of ormolu that uses four space indentation and allows arbitrary configuration.
 - [gci](https://github.com/daixiang0/gci) - GCI, a tool that controls Go package import order and makes it always deterministic.

--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ You can view this list in vim with `:help conform-formatters`
 - [fixjson](https://github.com/rhysd/fixjson) - JSON Fixer for Humans using (relaxed) JSON5.
 - [fnlfmt](https://git.sr.ht/~technomancy/fnlfmt) - A formatter for Fennel code.
 - [forge_fmt](https://github.com/foundry-rs/foundry) - Forge is a command-line tool that ships with Foundry. Forge tests, builds, and deploys your smart contracts.
-- [format-queries](https://github.com/nvim-treesitter/nvim-treesitter/blob/main/CONTRIBUTING.md#formatting) - Tree-sitter query formatter
+- [format-queries](https://github.com/nvim-treesitter/nvim-treesitter/blob/main/CONTRIBUTING.md#formatting) - Tree-sitter query formatter.
 - [fourmolu](https://hackage.haskell.org/package/fourmolu) - A fork of ormolu that uses four space indentation and allows arbitrary configuration.
 - [gci](https://github.com/daixiang0/gci) - GCI, a tool that controls Go package import order and makes it always deterministic.
 - [gdformat](https://github.com/Scony/godot-gdscript-toolkit) - A formatter for Godot's gdscript.

--- a/doc/conform.txt
+++ b/doc/conform.txt
@@ -260,6 +260,7 @@ FORMATTERS                                                    *conform-formatter
 `fnlfmt` - A formatter for Fennel code.
 `forge_fmt` - Forge is a command-line tool that ships with Foundry. Forge tests,
             builds, and deploys your smart contracts.
+`format-queries` - Tree-sitter query formatter
 `fourmolu` - A fork of ormolu that uses four space indentation and allows
            arbitrary configuration.
 `gci` - GCI, a tool that controls Go package import order and makes it always

--- a/doc/conform.txt
+++ b/doc/conform.txt
@@ -260,7 +260,7 @@ FORMATTERS                                                    *conform-formatter
 `fnlfmt` - A formatter for Fennel code.
 `forge_fmt` - Forge is a command-line tool that ships with Foundry. Forge tests,
             builds, and deploys your smart contracts.
-`format-queries` - Tree-sitter query formatter
+`format-queries` - Tree-sitter query formatter.
 `fourmolu` - A fork of ormolu that uses four space indentation and allows
            arbitrary configuration.
 `gci` - GCI, a tool that controls Go package import order and makes it always

--- a/lua/conform/formatters/format-queries.lua
+++ b/lua/conform/formatters/format-queries.lua
@@ -5,9 +5,10 @@ return {
     description = "Tree-sitter query formatter",
   },
   condition = function()
+    ---@diagnostic disable-next-line: param-type-mismatch
     local ok, _ = pcall(vim.treesitter.language.inspect("query"))
 
-    return ok or vim.api.nvim_get_runtime_file("scripts/format-queries.lua", false)[1] ~= nil
+    return ok and vim.api.nvim_get_runtime_file("scripts/format-queries.lua", false)[1] ~= nil
   end,
   command = "nvim",
   args = function()

--- a/lua/conform/formatters/format-queries.lua
+++ b/lua/conform/formatters/format-queries.lua
@@ -1,0 +1,23 @@
+---@type conform.FileFormatterConfig
+return {
+  meta = {
+    url = "https://github.com/nvim-treesitter/nvim-treesitter/blob/main/CONTRIBUTING.md#formatting",
+    description = "Tree-sitter query formatter",
+  },
+  condition = function()
+    local ok, _ = pcall(vim.treesitter.language.inspect("query"))
+
+    return ok or vim.api.nvim_get_runtime_file("scripts/format-queries.lua", false)[1] ~= nil
+  end,
+  command = "nvim",
+  args = function()
+    local args = { "-l" }
+    local exe = vim.api.nvim_get_runtime_file("scripts/format-queries.lua", false)[1]
+
+    table.insert(args, exe)
+    table.insert(args, "$FILENAME")
+
+    return args
+  end,
+  stdin = false,
+}

--- a/lua/conform/formatters/format-queries.lua
+++ b/lua/conform/formatters/format-queries.lua
@@ -1,24 +1,21 @@
+---@return nil|string
+local function get_format_script()
+  return vim.api.nvim_get_runtime_file("scripts/format-queries.lua", false)[1]
+end
+
 ---@type conform.FileFormatterConfig
 return {
   meta = {
     url = "https://github.com/nvim-treesitter/nvim-treesitter/blob/main/CONTRIBUTING.md#formatting",
-    description = "Tree-sitter query formatter",
+    description = "Tree-sitter query formatter.",
   },
   condition = function()
-    ---@diagnostic disable-next-line: param-type-mismatch
-    local ok, _ = pcall(vim.treesitter.language.inspect("query"))
-
-    return ok and vim.api.nvim_get_runtime_file("scripts/format-queries.lua", false)[1] ~= nil
+    local ok = pcall(vim.treesitter.language.inspect, "query")
+    return ok and get_format_script() ~= nil
   end,
   command = "nvim",
   args = function()
-    local args = { "-l" }
-    local exe = vim.api.nvim_get_runtime_file("scripts/format-queries.lua", false)[1]
-
-    table.insert(args, exe)
-    table.insert(args, "$FILENAME")
-
-    return args
+    return { "-l", get_format_script(), "$FILENAME" }
   end,
   stdin = false,
 }


### PR DESCRIPTION
I found out that nvim-treesitter comes with a formatter; that they themselves use to format their queries:\
https://github.com/nvim-treesitter/nvim-treesitter/blob/ea2b137f35fb1e87a6471ec311805920fdf45745/.github/workflows/lint.yml#L36-L51

They maintain it, and it [ships with the plugin](https://github.com/nvim-treesitter/nvim-treesitter/blob/ea2b137f35fb1e87a6471ec311805920fdf45745/scripts/format-queries.lua)... So why not use it?

I threw this a little hastily together; if you have some better ideas for the condition or anything else, please let me know :-)