### PR TITLE
unsaved files: smarter file name extension

### DIFF
--- a/lua/conform/ft_to_ext.lua
+++ b/lua/conform/ft_to_ext.lua
@@ -1,0 +1,13 @@
+return {
+  elixir = "ex",
+  graphql = "gql",
+  javascript = "js",
+  javascriptreact = "jsx",
+  markdown = "md",
+  perl = "pl",
+  python = "py",
+  ruby = "rb",
+  rust = "rs",
+  typescript = "ts",
+  typescriptreact = "tsx",
+}

--- a/lua/conform/runner.lua
+++ b/lua/conform/runner.lua
@@ -1,5 +1,6 @@
 local errors = require("conform.errors")
 local fs = require("conform.fs")
+local ft_to_ext = require("conform.ft_to_ext")
 local log = require("conform.log")
 local util = require("conform.util")
 local uv = vim.uv or vim.loop
@@ -457,7 +458,7 @@ M.build_context = function(bufnr, config, range)
     filename = fs.join(dirname, "unnamed_temp")
     local ft = vim.bo[bufnr].filetype
     if ft and ft ~= "" then
-      filename = filename .. "." .. ft
+      filename = filename .. "." .. (ft_to_ext[ft] or ft)
     end
   else
     dirname = vim.fs.dirname(filename)


### PR DESCRIPTION
the extension used to be always the file type, be smarter now. For instance prettier wouldn't recognize a `.typescript` extension.