### PR TITLE
feat: add support for d2

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,7 @@ You can view this list in vim with `:help conform-formatters`
 - [crystal](https://crystal-lang.org/) - Format Crystal code.
 - [csharpier](https://github.com/belav/csharpier) - The opinionated C# code formatter.
 - [cue_fmt](https://cuelang.org) - Format CUE files using `cue fmt` command.
+- [d2](https://github.com/terrastruct/d2) - D2 diagram formatter.
 - [darker](https://github.com/akaihola/darker) - Run black only on changed lines.
 - [dart_format](https://dart.dev/tools/dart-format) - Replace the whitespace in your program with formatting that follows Dart guidelines.
 - [deno_fmt](https://deno.land/manual/tools/formatter) - Use [Deno](https://deno.land/) to format TypeScript, JavaScript/JSON and markdown.

--- a/doc/conform.txt
+++ b/doc/conform.txt
@@ -238,6 +238,7 @@ FORMATTERS                                                    *conform-formatter
 `crystal` - Format Crystal code.
 `csharpier` - The opinionated C# code formatter.
 `cue_fmt` - Format CUE files using `cue fmt` command.
+`d2` - D2 diagram formatter.
 `darker` - Run black only on changed lines.
 `dart_format` - Replace the whitespace in your program with formatting that
               follows Dart guidelines.

--- a/lua/conform/formatters/d2.lua
+++ b/lua/conform/formatters/d2.lua
@@ -1,0 +1,9 @@
+---@type conform.FileFormatterConfig
+return {
+  meta = {
+    url = "https://github.com/terrastruct/d2",
+    description = "D2 is a modern diagram scripting language that turns text to diagrams",
+  },
+  command = "d2",
+  args = { "fmt", "-" },
+}

--- a/lua/conform/formatters/d2.lua
+++ b/lua/conform/formatters/d2.lua
@@ -2,7 +2,7 @@
 return {
   meta = {
     url = "https://github.com/terrastruct/d2",
-    description = "D2 is a modern diagram scripting language that turns text to diagrams",
+    description = "D2 is a modern diagram scripting language that turns text to diagrams.",
   },
   command = "d2",
   args = { "fmt", "-" },


### PR DESCRIPTION
As `d2` filetype is not defined for nvim at the time, you may need to `set filetype=d2` for this to work