### PR TITLE
feat: add support for for vsg

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,6 +335,7 @@ You can view this list in vim with `:help conform-formatters`
 - [uncrustify](https://github.com/uncrustify/uncrustify) - A source code beautifier for C, C++, C#, ObjectiveC, D, Java, Pawn and Vala.
 - [usort](https://github.com/facebook/usort) - Safe, minimal import sorting for Python projects.
 - [verible](https://github.com/chipsalliance/verible/blob/master/verilog/tools/formatter/README.md) - The SystemVerilog formatter.
+- [vsg](https://github.com/jeremiah-c-leary/vhdl-style-guide) - Style guide enforcement for VHDL.
 - [xmlformat](https://github.com/pamoller/xmlformatter) - xmlformatter is an Open Source Python package, which provides formatting of XML documents.
 - [xmllint](http://xmlsoft.org/xmllint.html) - Despite the name, xmllint can be used to format XML files as well as lint them.
 - [yamlfix](https://github.com/lyz-code/yamlfix) - A configurable YAML formatter that keeps comments.

--- a/doc/conform.txt
+++ b/doc/conform.txt
@@ -413,6 +413,7 @@ FORMATTERS                                                    *conform-formatter
              Pawn and Vala.
 `usort` - Safe, minimal import sorting for Python projects.
 `verible` - The SystemVerilog formatter.
+`vsg` - Style guide enforcement for VHDL.
 `xmlformat` - xmlformatter is an Open Source Python package, which provides
             formatting of XML documents.
 `xmllint` - Despite the name, xmllint can be used to format XML files as well as

--- a/lua/conform/formatters/vsg.lua
+++ b/lua/conform/formatters/vsg.lua
@@ -1,0 +1,38 @@
+local function find_local_config()
+  local current_file = vim.api.nvim_buf_get_name(0)
+  local local_configs = { ".vsg.yaml", ".vsg.yml", ".vsg.json" }
+  return vim.fs.find(local_configs, {
+    path = vim.fs.dirname(current_file),
+    upward = true,
+  })[1]
+end
+
+local function find_global_config()
+  local xdg_config_home = os.getenv("XDG_CONFIG_HOME") or os.getenv("HOME") .. "/.config"
+  local global_configs = { "vsg.yaml", "vsg.yml", "vsg.json" }
+  return vim.fs.find(global_configs, {
+    path = xdg_config_home .. "/vsg",
+    upward = false,
+  })[1]
+end
+
+---@type conform.FileFormatterConfig
+return {
+  meta = {
+    url = "https://github.com/jeremiah-c-leary/vhdl-style-guide",
+    description = "Style guide enforcement for VHDL.",
+  },
+  command = "vsg",
+  stdin = false,
+  args = function()
+    local args = { "-of", "syntastic", "--fix", "-f", "$FILENAME" }
+    local config_file = find_local_config() or find_global_config()
+
+    if config_file then
+      table.insert(args, "-c")
+      table.insert(args, config_file)
+    end
+
+    return args
+  end,
+}


### PR DESCRIPTION
Hi, love your project. This adds support for the [VHDL Style Guide](https://github.com/jeremiah-c-leary/vhdl-style-guide) (VSG) formatter.

The formatter doesn't auto-detect configuration files, so I added functionality to look for `.vsg.yaml` and `.vsg.json` in and under the file's directory and in `xdg-config/vsg` and `~/.config/vsg`. I couldn't find any mention of a standard name for said files in the documentation, but I saw some other people using these names and is also what I use myself. This might be out of scope, but it is quite nice to have, at least until they settle on something themselves or bake in the functionality. But please let me know what you think.
