### PR TITLE
feat!: expand options for LSP formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ require("conform").setup({
   format_on_save = {
     -- These options will be passed to conform.format()
     timeout_ms = 500,
-    lsp_fallback = true,
+    lsp_format = "fallback",
   },
 })
 ```
@@ -467,14 +467,14 @@ require("conform").setup({
   -- This can also be a function that returns the table.
   format_on_save = {
     -- I recommend these options. See :help conform.format for details.
-    lsp_fallback = true,
+    lsp_format = "fallback",
     timeout_ms = 500,
   },
   -- If this is set, Conform will run the formatter asynchronously after save.
   -- It will pass the table to conform.format().
   -- This can also be a function that returns the table.
   format_after_save = {
-    lsp_fallback = true,
+    lsp_format = "fallback",
   },
   -- Set the log level. Use `:ConformInfo` to see the location of the log file.
   log_level = vim.log.levels.ERROR,
@@ -575,21 +575,21 @@ require("conform").formatters.my_formatter = {
 `format(opts, callback): boolean` \
 Format a buffer
 
-| Param    | Type                                                 | Desc                                 |                                                                                                                                                      |
-| -------- | ---------------------------------------------------- | ------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
-| opts     | `nil\|conform.FormatOpts`                            |                                      |                                                                                                                                                      |
-|          | timeout_ms                                           | `nil\|integer`                       | Time in milliseconds to block for formatting. Defaults to 1000. No effect if async = true.                                                           |
-|          | bufnr                                                | `nil\|integer`                       | Format this buffer (default 0)                                                                                                                       |
-|          | async                                                | `nil\|boolean`                       | If true the method won't block. Defaults to false. If the buffer is modified before the formatter completes, the formatting will be discarded.       |
-|          | dry_run                                              | `nil\|boolean`                       | If true don't apply formatting changes to the buffer                                                                                                 |
-|          | formatters                                           | `nil\|string[]`                      | List of formatters to run. Defaults to all formatters for the buffer filetype.                                                                       |
-|          | lsp_fallback                                         | `nil\|boolean\|"always"`             | Attempt LSP formatting if no formatters are available. Defaults to false. If "always", will attempt LSP formatting even if formatters are available. |
-|          | quiet                                                | `nil\|boolean`                       | Don't show any notifications for warnings or failures. Defaults to false.                                                                            |
-|          | range                                                | `nil\|table`                         | Range to format. Table must contain `start` and `end` keys with {row, col} tuples using (1,0) indexing. Defaults to current selection in visual mode |
-|          | id                                                   | `nil\|integer`                       | Passed to vim.lsp.buf.format when lsp_fallback = true                                                                                                |
-|          | name                                                 | `nil\|string`                        | Passed to vim.lsp.buf.format when lsp_fallback = true                                                                                                |
-|          | filter                                               | `nil\|fun(client: table): boolean`   | Passed to vim.lsp.buf.format when lsp_fallback = true                                                                                                |
-| callback | `nil\|fun(err: nil\|string, did_edit: nil\|boolean)` | Called once formatting has completed |                                                                                                                                                      |
+| Param    | Type                                                 | Desc                                                  |                                                                                                                                                                                                |
+| -------- | ---------------------------------------------------- | ----------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| opts     | `nil\|conform.FormatOpts`                            |                                                       |                                                                                                                                                                                                |
+|          | timeout_ms                                           | `nil\|integer`                                        | Time in milliseconds to block for formatting. Defaults to 1000. No effect if async = true.                                                                                                     |
+|          | bufnr                                                | `nil\|integer`                                        | Format this buffer (default 0)                                                                                                                                                                 |
+|          | async                                                | `nil\|boolean`                                        | If true the method won't block. Defaults to false. If the buffer is modified before the formatter completes, the formatting will be discarded.                                                 |
+|          | dry_run                                              | `nil\|boolean`                                        | If true don't apply formatting changes to the buffer                                                                                                                                           |
+|          | formatters                                           | `nil\|string[]`                                       | List of formatters to run. Defaults to all formatters for the buffer filetype.                                                                                                                 |
+|          | lsp_format                                           | `nil\|"never"\|"fallback"\|"prefer"\|"first"\|"last"` | "fallback" LSP formatting when no other formatters are available, "prefer" only LSP formatting when available, "first" LSP formatting then other formatters, "last" other formatters then LSP. |
+|          | quiet                                                | `nil\|boolean`                                        | Don't show any notifications for warnings or failures. Defaults to false.                                                                                                                      |
+|          | range                                                | `nil\|table`                                          | Range to format. Table must contain `start` and `end` keys with {row, col} tuples using (1,0) indexing. Defaults to current selection in visual mode                                           |
+|          | id                                                   | `nil\|integer`                                        | Passed to vim.lsp.buf.format when using LSP formatting                                                                                                                                         |
+|          | name                                                 | `nil\|string`                                         | Passed to vim.lsp.buf.format when using LSP formatting                                                                                                                                         |
+|          | filter                                               | `nil\|fun(client: table): boolean`                    | Passed to vim.lsp.buf.format when using LSP formatting                                                                                                                                         |
+| callback | `nil\|fun(err: nil\|string, did_edit: nil\|boolean)` | Called once formatting has completed                  |                                                                                                                                                                                                |
 
 Returns:
 
@@ -625,7 +625,7 @@ Get information about a formatter (including availability)
 ### will_fallback_lsp(options)
 
 `will_fallback_lsp(options): boolean` \
-Check if the buffer will use LSP formatting when lsp_fallback = true
+Check if the buffer will use LSP formatting when lsp_format = "fallback"
 
 | Param   | Type         | Desc                                 |
 | ------- | ------------ | ------------------------------------ |

--- a/doc/conform.txt
+++ b/doc/conform.txt
@@ -38,14 +38,14 @@ OPTIONS                                                          *conform-option
       -- This can also be a function that returns the table.
       format_on_save = {
         -- I recommend these options. See :help conform.format for details.
-        lsp_fallback = true,
+        lsp_format = "fallback",
         timeout_ms = 500,
       },
       -- If this is set, Conform will run the formatter asynchronously after save.
       -- It will pass the table to conform.format().
       -- This can also be a function that returns the table.
       format_after_save = {
-        lsp_fallback = true,
+        lsp_format = "fallback",
       },
       -- Set the log level. Use `:ConformInfo` to see the location of the log file.
       log_level = vim.log.levels.ERROR,
@@ -142,32 +142,32 @@ format({opts}, {callback}): boolean                               *conform.forma
 
     Parameters:
       {opts}     `nil|conform.FormatOpts`
-          {timeout_ms}   `nil|integer` Time in milliseconds to block for
-                         formatting. Defaults to 1000. No effect if async =
-                         true.
-          {bufnr}        `nil|integer` Format this buffer (default 0)
-          {async}        `nil|boolean` If true the method won't block. Defaults
-                         to false. If the buffer is modified before the
-                         formatter completes, the formatting will be discarded.
-          {dry_run}      `nil|boolean` If true don't apply formatting changes to
-                         the buffer
-          {formatters}   `nil|string[]` List of formatters to run. Defaults to
-                         all formatters for the buffer filetype.
-          {lsp_fallback} `nil|boolean|"always"` Attempt LSP formatting if no
-                         formatters are available. Defaults to false. If
-                         "always", will attempt LSP formatting even if
-                         formatters are available.
-          {quiet}        `nil|boolean` Don't show any notifications for warnings
-                         or failures. Defaults to false.
-          {range}        `nil|table` Range to format. Table must contain `start`
-                         and `end` keys with {row, col} tuples using (1,0)
-                         indexing. Defaults to current selection in visual mode
-          {id}           `nil|integer` Passed to |vim.lsp.buf.format| when
-                         lsp_fallback = true
-          {name}         `nil|string` Passed to |vim.lsp.buf.format| when
-                         lsp_fallback = true
-          {filter}       `nil|fun(client: table): boolean` Passed to
-                         |vim.lsp.buf.format| when lsp_fallback = true
+          {timeout_ms} `nil|integer` Time in milliseconds to block for
+                       formatting. Defaults to 1000. No effect if async = true.
+          {bufnr}      `nil|integer` Format this buffer (default 0)
+          {async}      `nil|boolean` If true the method won't block. Defaults to
+                       false. If the buffer is modified before the formatter
+                       completes, the formatting will be discarded.
+          {dry_run}    `nil|boolean` If true don't apply formatting changes to
+                       the buffer
+          {formatters} `nil|string[]` List of formatters to run. Defaults to all
+                       formatters for the buffer filetype.
+          {lsp_format} `nil|"never"|"fallback"|"prefer"|"first"|"last"` "fallbac
+                       k" LSP formatting when no other formatters are available,
+                       "prefer" only LSP formatting when available, "first" LSP
+                       formatting then other formatters, "last" other formatters
+                       then LSP.
+          {quiet}      `nil|boolean` Don't show any notifications for warnings
+                       or failures. Defaults to false.
+          {range}      `nil|table` Range to format. Table must contain `start`
+                       and `end` keys with {row, col} tuples using (1,0)
+                       indexing. Defaults to current selection in visual mode
+          {id}         `nil|integer` Passed to |vim.lsp.buf.format| when using
+                       LSP formatting
+          {name}       `nil|string` Passed to |vim.lsp.buf.format| when using
+                       LSP formatting
+          {filter}     `nil|fun(client: table): boolean` Passed to
+                       |vim.lsp.buf.format| when using LSP formatting
       {callback} `nil|fun(err: nil|string, did_edit: nil|boolean)` Called once
                  formatting has completed
     Returns:
@@ -191,7 +191,7 @@ get_formatter_info({formatter}, {bufnr}): conform.FormatterInfo *conform.get_for
       {bufnr}     `nil|integer`
 
 will_fallback_lsp({options}): boolean                  *conform.will_fallback_lsp*
-    Check if the buffer will use LSP formatting when lsp_fallback = true
+    Check if the buffer will use LSP formatting when lsp_format = "fallback"
 
     Parameters:
       {options} `nil|table` Options passed to |vim.lsp.buf.format|

--- a/doc/recipes.md
+++ b/doc/recipes.md
@@ -24,7 +24,7 @@ vim.api.nvim_create_user_command("Format", function(args)
       ["end"] = { args.line2, end_line:len() },
     }
   end
-  require("conform").format({ async = true, lsp_fallback = true, range = range })
+  require("conform").format({ async = true, lsp_format = "fallback", range = range })
 end, { range = true })
 ```
 
@@ -53,7 +53,7 @@ require("conform").setup({
       return
     end
     -- ...additional logic...
-    return { timeout_ms = 500, lsp_fallback = true }
+    return { timeout_ms = 500, lsp_format = "fallback" }
   end,
 })
 
@@ -65,7 +65,7 @@ require("conform").setup({
       return
     end
     -- ...additional logic...
-    return { lsp_fallback = true }
+    return { lsp_format = "fallback" }
   end,
 })
 ```
@@ -83,7 +83,7 @@ require("conform").setup({
     if vim.g.disable_autoformat or vim.b[bufnr].disable_autoformat then
       return
     end
-    return { timeout_ms = 500, lsp_fallback = true }
+    return { timeout_ms = 500, lsp_format = "fallback" }
   end,
 })
 
@@ -123,14 +123,14 @@ require("conform").setup({
       end
     end
 
-    return { timeout_ms = 200, lsp_fallback = true }, on_format
+    return { timeout_ms = 200, lsp_format = "fallback" }, on_format
   end,
 
   format_after_save = function(bufnr)
     if not slow_format_filetypes[vim.bo[bufnr].filetype] then
       return
     end
-    return { lsp_fallback = true }
+    return { lsp_format = "fallback" }
   end,
 })
 ```
@@ -149,7 +149,7 @@ return {
       -- Customize or remove this keymap to your liking
       "<leader>f",
       function()
-        require("conform").format({ async = true, lsp_fallback = true })
+        require("conform").format({ async = true, lsp_format = "fallback" })
       end,
       mode = "",
       desc = "Format buffer",
@@ -164,7 +164,7 @@ return {
       javascript = { { "prettierd", "prettier" } },
     },
     -- Set up format-on-save
-    format_on_save = { timeout_ms = 500, lsp_fallback = true },
+    format_on_save = { timeout_ms = 500, lsp_format = "fallback" },
     -- Customize formatters
     formatters = {
       shfmt = {

--- a/scripts/autoformat_doc.lua
+++ b/scripts/autoformat_doc.lua
@@ -16,7 +16,7 @@ require("conform").setup({
       return
     end
     -- ...additional logic...
-    return { timeout_ms = 500, lsp_fallback = true }
+    return { timeout_ms = 500, lsp_format = "fallback" }
   end,
 })
 
@@ -28,6 +28,6 @@ require("conform").setup({
       return
     end
     -- ...additional logic...
-    return { lsp_fallback = true }
+    return { lsp_format = "fallback" }
   end,
 })

--- a/scripts/options_doc.lua
+++ b/scripts/options_doc.lua
@@ -25,14 +25,14 @@ require("conform").setup({
   -- This can also be a function that returns the table.
   format_on_save = {
     -- I recommend these options. See :help conform.format for details.
-    lsp_fallback = true,
+    lsp_format = "fallback",
     timeout_ms = 500,
   },
   -- If this is set, Conform will run the formatter asynchronously after save.
   -- It will pass the table to conform.format().
   -- This can also be a function that returns the table.
   format_after_save = {
-    lsp_fallback = true,
+    lsp_format = "fallback",
   },
   -- Set the log level. Use `:ConformInfo` to see the location of the log file.
   log_level = vim.log.levels.ERROR,


### PR DESCRIPTION
This deprecates the `lsp_fallback` option (gracefully; it should continue to work) and replaces it with the `lsp_format` enum which can be several values. Three of the values produce behavior that was possible with `lsp_fallback`, and two of them are new behaviors. The new behaviors fix #316 

| lsp_format | lsp_fallback | description |
| -- | -- | -- |
| nil or "never" | nil or false | Do not use LSP formatting |
| "fallback" | true | Use LSP formatting if there are no formatters configured for this filetype |
| "prefer" | - | Use LSP formatting when it is available, otherwise fall back to the formatters configured for this filetype |
| "last" | "always" | Run configured formatters, then run LSP formatting |
| "first" | - | Run LSP formatting, then run configured formatters |