### PR TITLE
fix: avoid returning a filetype if its formatter array is empty

### DIFF
--- a/lua/conform/init.lua
+++ b/lua/conform/init.lua
@@ -177,7 +177,7 @@ local function get_matching_filetype(bufnr)
   table.insert(filetypes, "_")
   for _, filetype in ipairs(filetypes) do
     local ft_formatters = M.formatters_by_ft[filetype]
-    if ft_formatters then
+    if ft_formatters and not vim.tbl_isempty(ft_formatters) then
       return filetype
     end
   end


### PR DESCRIPTION
When using the below configuration

    {
        format = { lsp_fallback = true, lsp_format = 'fallback' },  // old and new
        formatters = { injected = { options = { ignore_errors = true } }, },
        formatters_by_ft = { lua = {} },  // to override the default LazyVim setting [1]
    }

Previously when explicit_formatters [2] was true, it relied on lsp_fallback and lsp_format.get_format_clients() [3], so LSP formatters were called normally.

However now in has_filetype_formatters(), it relies on get_matching_filetype() directly, hence revealing this issue.

[1] https://github.com/LazyVim/LazyVim/blob/8a89c0360e4a076b99b09fe673fbd947f71577fc/lua/lazyvim/plugins/formatting.lua#L73
[2] https://github.com/stevearc/conform.nvim/commit/9228b2ff4efd58b6e081defec643bf887ebadff6#diff-04c07f595c94cd9a5acd85c268fac3d332438f3f9658740ab348e99bb82db631L354
[3] https://github.com/stevearc/conform.nvim/commit/9228b2ff4efd58b6e081defec643bf887ebadff6#diff-04c07f595c94cd9a5acd85c268fac3d332438f3f9658740ab348e99bb82db631L411