### PR TITLE
fix: ignore empty opts.formatters like nil

### DIFF
--- a/lua/conform/init.lua
+++ b/lua/conform/init.lua
@@ -378,6 +378,9 @@ M.format = function(opts, callback)
   local lsp_format = require("conform.lsp_format")
   local runner = require("conform.runner")
 
+  if is_empty_table(opts.formatters) then
+    opts.formatters = nil
+  end
   local explicit_formatters = opts.formatters ~= nil
   local formatter_names = opts.formatters or M.list_formatters_for_buffer(opts.bufnr)
   local formatters =


### PR DESCRIPTION
Same rationale as [1]. When there are no LSP formatters and opts.formatters = {}, we should normally call
list_formatters_for_buffer.

[1] https://github.com/stevearc/conform.nvim/commit/bde3bee1773c96212b6c49f009e05174f932c23a