### PR TITLE
feat(djlint): respect local buffer tabstop config

### DIFF
--- a/lua/conform/formatters/djlint.lua
+++ b/lua/conform/formatters/djlint.lua
@@ -6,10 +6,10 @@ return {
     description = "✨ HTML Template Linter and Formatter. Django - Jinja - Nunjucks - Handlebars - GoLang.",
   },
   command = "djlint",
-  args = {
-    "--reformat",
-    "-",
-  },
+  args = function(_, ctx)
+    local indent = vim.bo[ctx.buf].tabstop or 4 -- default is 4
+    return { "--reformat", "--indent", indent, "-" }
+  end,
   cwd = util.root_file({
     ".djlintrc",
   }),


### PR DESCRIPTION
Formatter now able to use local buffer tabstop config. One of the case is when the tabstop is set by editorconfig.

Close #457