### PR TITLE
doc: Add recipe to immediately display formatter error output

### DIFF
--- a/README.md
+++ b/README.md
@@ -429,6 +429,7 @@ require("conform").formatters.shfmt = {
 - [Command to toggle format-on-save](doc/recipes.md#command-to-toggle-format-on-save)
 - [Automatically run slow formatters async](doc/recipes.md#automatically-run-slow-formatters-async)
 - [Lazy loading with lazy.nvim](doc/recipes.md#lazy-loading-with-lazynvim)
+- [Display error message](doc/recipes.md#display-error-message)
 
 <!-- /RECIPES -->
 

--- a/doc/recipes.md
+++ b/doc/recipes.md
@@ -7,6 +7,7 @@
 - [Command to toggle format-on-save](#command-to-toggle-format-on-save)
 - [Automatically run slow formatters async](#automatically-run-slow-formatters-async)
 - [Lazy loading with lazy.nvim](#lazy-loading-with-lazynvim)
+- [Display error message](#display-error-message)
 
 <!-- /TOC -->
 
@@ -177,4 +178,52 @@ return {
     vim.o.formatexpr = "v:lua.require'conform'.formatexpr()"
   end,
 }
+```
+
+## Display error message
+
+Display formatter output if it fails or explanation if it is unable to run. A message similar to one below will show up on the bottom of the screen (using default `vim.notify`).
+
+```
+Formatter 'rustfmt' error: error: expected `;`, found `bar`
+ --> <stdin>:2:10
+  |
+2 |     foo()
+  |          ^ help: add `;` here
+3 |     bar()
+  |     --- unexpected token
+
+Press ENTER or type command to continue
+```
+
+```lua
+local function notify_on_error(err)
+  if err then
+    vim.notify(err, vim.log.levels.WARN)
+  end
+end
+
+-- Show error message in manual invocation
+vim.keymap.set("<leader>f", function()
+  local format_opts = {
+    -- ...
+  }
+  require("conform").format(format_opts, notify_on_error)
+end, { desc = "Format buffer" })
+
+-- Show error message on/after save
+require("conform").setup({
+  format_on_save = function(bufnr)
+    local format_opts = {
+      -- ...
+    }
+    return format_opts, notify_on_error
+  end,
+  format_after_save = function(bufnr)
+    local format_opts = {
+      -- ...
+    }
+    return format_opts, notify_on_error
+  end,
+})
 ```


### PR DESCRIPTION
Add a recipe that show cases how to display formatter output if it fails or explanation if it is unable to run.

A nice error message, similar to one below, will show up on the bottom of the screen to help quickly spot an error:

```
Formatter 'rustfmt' error: error: expected `;`, found `bar`
 --> <stdin>:2:10
  |
2 |     foo()
  |          ^ help: add `;` here
3 |     bar()
  |     --- unexpected token

Press ENTER or type command to continue
```

P.S. I think this would be nice to have enabled by default. Given that it would probably help to reduce frustration when formatter wasn't actually found/installed, or absence of formatting action wasn't immediately obvious (hint to check conform log appears only once). And this doesn't seem to anyhow worsen the experience.