### PR TITLE
feat(shfmt): add automatic indentation detection

### DIFF
--- a/lua/conform/formatters/djlint.lua
+++ b/lua/conform/formatters/djlint.lua
@@ -7,8 +7,12 @@ return {
   },
   command = "djlint",
   args = function(_, ctx)
-    local indent = vim.bo[ctx.buf].tabstop or 4 -- default is 4
-    return { "--reformat", "--indent", indent, "-" }
+    local bo = vim.bo[ctx.buf]
+    local indent_size = bo.shiftwidth
+    if indent_size == 0 or not indent_size then
+      indent_size = bo.tabstop or 4 -- default is 4
+    end
+    return { "--reformat", "--indent", indent_size, "-" }
   end,
   cwd = util.root_file({
     ".djlintrc",

--- a/lua/conform/formatters/djlint.lua
+++ b/lua/conform/formatters/djlint.lua
@@ -7,12 +7,7 @@ return {
   },
   command = "djlint",
   args = function(_, ctx)
-    local bo = vim.bo[ctx.buf]
-    local indent_size = bo.shiftwidth
-    if indent_size == 0 or not indent_size then
-      indent_size = bo.tabstop or 4 -- default is 4
-    end
-    return { "--reformat", "--indent", indent_size, "-" }
+    return { "--reformat", "--indent", ctx.shiftwidth, "-" }
   end,
   cwd = util.root_file({
     ".djlintrc",

--- a/lua/conform/formatters/markdown-toc.lua
+++ b/lua/conform/formatters/markdown-toc.lua
@@ -6,10 +6,18 @@ return {
   },
   command = "markdown-toc",
   stdin = false,
-  args = function(self, ctx)
+  args = function(_, ctx)
     -- use the indentation set in the current buffer, effectively allowing us to
     -- use values from .editorconfig
-    local indent = vim.bo[ctx.buf].expandtab and (" "):rep(vim.bo[ctx.buf].tabstop) or "\t"
+    local indent = "\t"
+    local bo = vim.bo[ctx.buf]
+    if bo.expandtab then
+      local indent_size = bo.shiftwidth
+      if indent_size == 0 or not indent_size then
+        indent_size = bo.tabstop or 4 -- default is 4
+      end
+      indent = (" "):rep(indent_size)
+    end
     return { "--indent=" .. indent, "-i", "$FILENAME" }
   end,
 }

--- a/lua/conform/formatters/markdown-toc.lua
+++ b/lua/conform/formatters/markdown-toc.lua
@@ -9,15 +9,7 @@ return {
   args = function(_, ctx)
     -- use the indentation set in the current buffer, effectively allowing us to
     -- use values from .editorconfig
-    local indent = "\t"
-    local bo = vim.bo[ctx.buf]
-    if bo.expandtab then
-      local indent_size = bo.shiftwidth
-      if indent_size == 0 or not indent_size then
-        indent_size = bo.tabstop or 4 -- default is 4
-      end
-      indent = (" "):rep(indent_size)
-    end
+    local indent = vim.bo[ctx.buf].expandtab and (" "):rep(ctx.shiftwidth) or "\t"
     return { "--indent=" .. indent, "-i", "$FILENAME" }
   end,
 }

--- a/lua/conform/formatters/shfmt.lua
+++ b/lua/conform/formatters/shfmt.lua
@@ -5,5 +5,16 @@ return {
     description = "A shell parser, formatter, and interpreter with `bash` support.",
   },
   command = "shfmt",
-  args = { "-filename", "$FILENAME" },
+  args = function(_, ctx)
+    local args = { "-filename", "$FILENAME" }
+    local bo = vim.bo[ctx.buf]
+    if bo.expandtab then
+      local indent_size = bo.shiftwidth
+      if indent_size == 0 or not indent_size then
+        indent_size = bo.tabstop or 2
+      end
+      vim.list_extend(args, { "-i", tostring(indent_size) })
+    end
+    return args
+  end,
 }

--- a/lua/conform/formatters/shfmt.lua
+++ b/lua/conform/formatters/shfmt.lua
@@ -7,13 +7,8 @@ return {
   command = "shfmt",
   args = function(_, ctx)
     local args = { "-filename", "$FILENAME" }
-    local bo = vim.bo[ctx.buf]
-    if bo.expandtab then
-      local indent_size = bo.shiftwidth
-      if indent_size == 0 or not indent_size then
-        indent_size = bo.tabstop or 2
-      end
-      vim.list_extend(args, { "-i", tostring(indent_size) })
+    if vim.bo[ctx.buf].expandtab then
+      vim.list_extend(args, { "-i", ctx.shiftwidth })
     end
     return args
   end,

--- a/lua/conform/runner.lua
+++ b/lua/conform/runner.lua
@@ -450,6 +450,11 @@ M.build_context = function(bufnr, config, range)
   end
   local filename = vim.api.nvim_buf_get_name(bufnr)
 
+  local shiftwidth = vim.bo[bufnr].shiftwidth
+  if shiftwidth == 0 then
+    shiftwidth = vim.bo[bufnr].tabstop
+  end
+
   -- Hack around checkhealth. For buffers that are not files, we need to fabricate a filename
   if vim.bo[bufnr].buftype ~= "" then
     filename = ""
@@ -482,6 +487,7 @@ M.build_context = function(bufnr, config, range)
     filename = filename,
     dirname = dirname,
     range = range,
+    shiftwidth = shiftwidth,
   }
 end
 

--- a/lua/conform/types.lua
+++ b/lua/conform/types.lua
@@ -49,6 +49,7 @@
 ---@field filename string
 ---@field dirname string
 ---@field range? conform.Range
+---@field shiftwidth integer
 
 ---@class (exact) conform.RangeContext : conform.Context
 ---@field range conform.Range

--- a/tests/runner_spec.lua
+++ b/tests/runner_spec.lua
@@ -59,11 +59,36 @@ describe("runner", function()
       local config = assert(conform.get_formatter_config("test"))
       local ctx = runner.build_context(0, config)
       local filename = vim.api.nvim_buf_get_name(bufnr)
-      assert.are.same({
-        buf = bufnr,
-        filename = filename,
-        dirname = vim.fs.dirname(filename),
-      }, ctx)
+      assert.equal(bufnr, ctx.buf)
+      assert.equal(filename, ctx.filename)
+      assert.equal(vim.fs.dirname(filename), ctx.dirname)
+    end)
+
+    it("sets the shiftwidth to shiftwidth", function()
+      vim.cmd.edit({ args = { "README.md" } })
+      local bufnr = vim.api.nvim_get_current_buf()
+      vim.bo[bufnr].shiftwidth = 7
+      conform.formatters.test = {
+        meta = { url = "", description = "" },
+        command = "echo",
+      }
+      local config = assert(conform.get_formatter_config("test"))
+      local ctx = runner.build_context(0, config)
+      assert.equal(7, ctx.shiftwidth)
+    end)
+
+    it("sets the shiftwidth to tabstop as fallback", function()
+      vim.cmd.edit({ args = { "README.md" } })
+      local bufnr = vim.api.nvim_get_current_buf()
+      vim.bo[bufnr].shiftwidth = 0
+      vim.bo[bufnr].tabstop = 3
+      conform.formatters.test = {
+        meta = { url = "", description = "" },
+        command = "echo",
+      }
+      local config = assert(conform.get_formatter_config("test"))
+      local ctx = runner.build_context(0, config)
+      assert.equal(3, ctx.shiftwidth)
     end)
 
     it("sets temp file when stdin = false", function()


### PR DESCRIPTION
This adds the automatic setting of `-i` so that `shfmt` follows the current indentation settings of neovim. Whether it is manually set by the user or set through external factors such as `.editorconfig`

I also checked to see if this is done elsewhere for other formatters and found a couple others which I was able to improve the "correctness" of their indentation size calculations

EDIT: I was thinking about this and it seems like having the effective `shiftwidth` value is quite nice. And because this seems to be "contextual information" it seemed natural to put it in the `conform.Context` type since it is virtually free to calculate performance wise. Let me know if you disagree. Another approach would be to make some sort of utility module that is imported by formatters on an as needed basis that calculates this. This is basically the same as `vim.fn.shiftwidth` (`:h shiftwidth()`) with the only difference being that it calculates it specifically for the buffer in the context rather than the "current buffer". This allowed for a very nice refactor across the formatters that utilize this field and is available for future formatters. Also nice to make sure we have a common method for calculating indentation size.

Also `shiftwidth` and `tabstop` are always integers according to the neovim docs so no need to have default fallbacks or check for `nil`