### PR TITLE
fix(biome-check): use --write instead of deprecated --apply

### DIFF
--- a/lua/conform/formatters/biome-check.lua
+++ b/lua/conform/formatters/biome-check.lua
@@ -7,7 +7,7 @@ return {
   },
   command = util.from_node_modules("biome"),
   stdin = true,
-  args = { "check", "--apply", "--stdin-file-path", "$FILENAME" },
+  args = { "check", "--write", "--stdin-file-path", "$FILENAME" },
   cwd = util.root_file({
     "biome.json",
     "biome.jsonc",


### PR DESCRIPTION
biome deprecated --apply.
```

--apply   Alias for `--write`, writes safe fixes, formatting and import sorting 
          (deprecated, use `--write`)

```