### PR TITLE
Adds Swiftlint formatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,6 +330,7 @@ You can view this list in vim with `:help conform-formatters`
 - [stylua](https://github.com/JohnnyMorganz/StyLua) - An opinionated code formatter for Lua.
 - [swift_format](https://github.com/apple/swift-format) - Swift formatter from apple. Requires building from source with `swift build`.
 - [swiftformat](https://github.com/nicklockwood/SwiftFormat) - SwiftFormat is a code library and command-line tool for reformatting `swift` code on macOS or Linux.
+- [swiftlint](https://github.com/realm/SwiftLint)  - A tool to enforce Swift style and conventions.
 - [taplo](https://github.com/tamasfe/taplo) - A TOML toolkit written in Rust.
 - [templ](https://templ.guide/commands-and-tools/cli/#formatting-templ-files) - Formats templ template files.
 - [terraform_fmt](https://www.terraform.io/docs/cli/commands/fmt.html) - The terraform-fmt command rewrites `terraform` configuration files to a canonical format and style.

--- a/lua/conform/formatters/swiftlint.lua
+++ b/lua/conform/formatters/swiftlint.lua
@@ -1,0 +1,11 @@
+---@type conform.FileFormatterConfig
+return {
+  meta = {
+    url = "https://github.com/realm/SwiftLint",
+    description = "A tool to enforce Swift style and conventions.",
+  },
+  command = "swiftlint",
+  stdin = true,
+  args = { "lint", "--use-stdin", "--fix", "--format" },
+  cwd = require("conform.util").root_file({ ".swiftlint.yml", "Package.swift" }),
+}


### PR DESCRIPTION
I've added [swiftlint](https://github.com/realm/SwiftLint) as a formatter, I've tested over the weekend and it works great.

The command used to format is as follows:
```sh
swiftlint lint \
  --use-stdin \ # take input from stdin
  --fix \ # automatically fix errors where possible
  --format # apply sourcekit lsp default formatting if available
```

