### PR TITLE
feat(formatters): add nixfmt-rfc-style

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,8 +281,7 @@ You can view this list in vim with `:help conform-formatters`
 - [mix](https://hexdocs.pm/mix/main/Mix.Tasks.Format.html) - Format Elixir files using the mix format command.
 - [nickel](https://nickel-lang.org/) - Code formatter for the Nickel programming language.
 - [nimpretty](https://github.com/nim-lang/nim) - nimpretty is a Nim source code beautifier that follows the official style guide.
-- [nixfmt](https://github.com/serokell/nixfmt) - nixfmt is a formatter for Nix code, intended to apply a uniform style.
-- [nixfmt-rfc-style](https://github.com/NixOS/nixfmt) - The official (but not yet stable) formatter for Nix code.
+- [nixfmt](https://github.com/NixOS/nixfmt) - The official (but not yet stable) formatter for Nix code.
 - [nixpkgs_fmt](https://github.com/nix-community/nixpkgs-fmt) - nixpkgs-fmt is a Nix code formatter for nixpkgs.
 - [npm-groovy-lint](https://github.com/nvuillam/npm-groovy-lint) - Lint, format and auto-fix your Groovy / Jenkinsfile / Gradle files using command line.
 - [ocamlformat](https://github.com/ocaml-ppx/ocamlformat) - Auto-formatter for OCaml code.

--- a/README.md
+++ b/README.md
@@ -282,6 +282,7 @@ You can view this list in vim with `:help conform-formatters`
 - [nickel](https://nickel-lang.org/) - Code formatter for the Nickel programming language.
 - [nimpretty](https://github.com/nim-lang/nim) - nimpretty is a Nim source code beautifier that follows the official style guide.
 - [nixfmt](https://github.com/serokell/nixfmt) - nixfmt is a formatter for Nix code, intended to apply a uniform style.
+- [nixfmt-rfc-style](https://github.com/NixOS/nixfmt) - The official (but not yet stable) formatter for Nix code.
 - [nixpkgs_fmt](https://github.com/nix-community/nixpkgs-fmt) - nixpkgs-fmt is a Nix code formatter for nixpkgs.
 - [npm-groovy-lint](https://github.com/nvuillam/npm-groovy-lint) - Lint, format and auto-fix your Groovy / Jenkinsfile / Gradle files using command line.
 - [ocamlformat](https://github.com/ocaml-ppx/ocamlformat) - Auto-formatter for OCaml code.

--- a/doc/conform.txt
+++ b/doc/conform.txt
@@ -393,6 +393,7 @@ FORMATTERS                                                    *conform-formatter
             official style guide.
 `nixfmt` - nixfmt is a formatter for Nix code, intended to apply a uniform
          style.
+`nixfmt-rfc-style` - The official (but not yet stable) formatter for Nix code.
 `nixpkgs_fmt` - nixpkgs-fmt is a Nix code formatter for nixpkgs.
 `npm-groovy-lint` - Lint, format and auto-fix your Groovy / Jenkinsfile / Gradle
                   files using command line.

--- a/doc/conform.txt
+++ b/doc/conform.txt
@@ -391,9 +391,7 @@ FORMATTERS                                                    *conform-formatter
 `nickel` - Code formatter for the Nickel programming language.
 `nimpretty` - nimpretty is a Nim source code beautifier that follows the
             official style guide.
-`nixfmt` - nixfmt is a formatter for Nix code, intended to apply a uniform
-         style.
-`nixfmt-rfc-style` - The official (but not yet stable) formatter for Nix code.
+`nixfmt` - The official (but not yet stable) formatter for Nix code.
 `nixpkgs_fmt` - nixpkgs-fmt is a Nix code formatter for nixpkgs.
 `npm-groovy-lint` - Lint, format and auto-fix your Groovy / Jenkinsfile / Gradle
                   files using command line.

--- a/lua/conform/formatters/nixfmt-rfc-style.lua
+++ b/lua/conform/formatters/nixfmt-rfc-style.lua
@@ -1,8 +1,0 @@
----@type conform.FileFormatterConfig
-return {
-  meta = {
-    url = "https://github.com/NixOS/nixfmt",
-    description = "The official (but not yet stable) formatter for Nix code",
-  },
-  command = "nixfmt",
-}

--- a/lua/conform/formatters/nixfmt-rfc-style.lua
+++ b/lua/conform/formatters/nixfmt-rfc-style.lua
@@ -1,0 +1,8 @@
+---@type conform.FileFormatterConfig
+return {
+  meta = {
+    url = "https://github.com/NixOS/nixfmt",
+    description = "The official (but not yet stable) formatter for Nix code",
+  },
+  command = "nixfmt",
+}

--- a/lua/conform/formatters/nixfmt.lua
+++ b/lua/conform/formatters/nixfmt.lua
@@ -1,8 +1,8 @@
 ---@type conform.FileFormatterConfig
 return {
   meta = {
-    url = "https://github.com/serokell/nixfmt",
-    description = "nixfmt is a formatter for Nix code, intended to apply a uniform style.",
+    url = "https://github.com/NixOS/nixfmt",
+    description = "The official (but not yet stable) formatter for Nix code",
   },
   command = "nixfmt",
 }

--- a/lua/conform/formatters/nixfmt.lua
+++ b/lua/conform/formatters/nixfmt.lua
@@ -2,7 +2,7 @@
 return {
   meta = {
     url = "https://github.com/NixOS/nixfmt",
-    description = "The official (but not yet stable) formatter for Nix code",
+    description = "The official (but not yet stable) formatter for Nix code.",
   },
   command = "nixfmt",
 }


### PR DESCRIPTION
This is different from `nixfmt`, which is currently defined at:
https://github.com/stevearc/conform.nvim/blob/25d48271e3d4404ba017cb92a37d3a681c1ad149/lua/conform/formatters/nixfmt.lua

This new formatter is meant to eventually replace `nixfmt`. More information can be found on [their repo](https://github.com/NixOS/nixfmt)