### PR TITLE
feat: add support for markdownfmt

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,7 @@ You can view this list in vim with `:help conform-formatters`
 - [llf](https://repo.or.cz/llf.git) - A LaTeX reformatter / beautifier.
 - [lua-format](https://github.com/Koihik/LuaFormatter) - Code formatter for Lua.
 - [markdown-toc](https://github.com/jonschlinkert/markdown-toc) - API and CLI for generating a markdown TOC (table of contents) for a README or any markdown files.
+- [markdownfmt](https://github.com/shurcooL/markdownfmt) - Like gofmt, but for Markdown.
 - [markdownlint](https://github.com/DavidAnson/markdownlint) - A Node.js style checker and lint tool for Markdown/CommonMark files.
 - [markdownlint-cli2](https://github.com/DavidAnson/markdownlint-cli2) - A fast, flexible, configuration-based command-line interface for linting Markdown/CommonMark files with the markdownlint library.
 - [mdformat](https://github.com/executablebooks/mdformat) - An opinionated Markdown formatter.

--- a/doc/conform.txt
+++ b/doc/conform.txt
@@ -378,6 +378,7 @@ FORMATTERS                                                    *conform-formatter
 `lua-format` - Code formatter for Lua.
 `markdown-toc` - API and CLI for generating a markdown TOC (table of contents)
                for a README or any markdown files.
+`markdownfmt` - Like gofmt, but for Markdown.
 `markdownlint` - A Node.js style checker and lint tool for Markdown/CommonMark
                files.
 `markdownlint-cli2` - A fast, flexible, configuration-based command-line

--- a/lua/conform/formatters/markdownfmt.lua
+++ b/lua/conform/formatters/markdownfmt.lua
@@ -1,0 +1,8 @@
+---@type conform.FileFormatterConfig
+return {
+  meta = {
+    url = "https://github.com/shurcooL/markdownfmt",
+    description = "Like gofmt, but for Markdown.",
+  },
+  command = "markdownfmt",
+}


### PR DESCRIPTION
Adding support for markdownfmt. I opted to not include `find_executable` in the command since it's installed via `go install`, and gopath might differ between machines.

I have tested it and it seem to be working fine as long as the executable is reachable from PATH.