### PR TITLE
Update README to use sublist for running first available formatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,8 +131,8 @@ require("conform").setup({
     python = { "isort", "black" },
     -- You can customize some of the format options for the filetype (:help conform.format)
     rust = { "rustfmt", lsp_format = "fallback" },
-    -- Conform will run the first available formatter
-    javascript = { "prettierd", "prettier", stop_after_first = true },
+    -- Use a sub-list to run only the first available formatter
+    javascript = { { "prettierd", "prettier" } },
   },
 })
 ```


### PR DESCRIPTION
```gitdiff
-    -- Conform will run the first available formatter
-    javascript = { "prettierd", "prettier", stop_after_first = true },
+    -- Use a sub-list to run only the first available formatter
+    javascript = { { "prettierd", "prettier" } },
```