### PR TITLE
Remove indent command line argument for djlint

### DIFF
--- a/lua/conform/formatters/djlint.lua
+++ b/lua/conform/formatters/djlint.lua
@@ -6,9 +6,10 @@ return {
     description = "✨ HTML Template Linter and Formatter. Django - Jinja - Nunjucks - Handlebars - GoLang.",
   },
   command = "djlint",
-  args = function(_, ctx)
-    return { "--reformat", "--indent", ctx.shiftwidth, "-" }
-  end,
+  args = {
+    "--reformat",
+    "-",
+  },
   cwd = util.root_file({
     ".djlintrc",
   }),


### PR DESCRIPTION
When we pass cli arguments to `djlint`, they override those set in the configuration files: https://www.djlint.com/docs/configuration

I'd expect the formatter to respect the configuration file. If a user wants to override they can do so https://github.com/stevearc/conform.nvim/issues/457#issuecomment-2169139931.

This PR reverts the changes made in #467.

