### PR TITLE
fix(docformatter): update exit_codes, 3 is correct in in-place formatting

### DIFF
--- a/lua/conform/formatters/docformatter.lua
+++ b/lua/conform/formatters/docformatter.lua
@@ -7,4 +7,5 @@ return {
   command = "docformatter",
   args = { "--in-place", "$FILENAME" },
   stdin = false,
+  exit_codes = { 0, 3 },
 }


### PR DESCRIPTION
Fixes error `Formatter 'docformatter' error: unknown error` 

According to the [documentation](https://docformatter.readthedocs.io/en/latest/usage.html) on possible exit_codes: 

> 3 - if any file needs to be formatted (in --check or --in-place mode)

Which is expected when the document needs actual formatting 
