### PR TITLE
fix(sqlfluff): don't assume ansi dialect and require config

### DIFF
--- a/lua/conform/formatters/sqlfluff.lua
+++ b/lua/conform/formatters/sqlfluff.lua
@@ -7,7 +7,7 @@ return {
     description = "A modular SQL linter and auto-formatter with support for multiple dialects and templated code.",
   },
   command = "sqlfluff",
-  args = { "fix", "--dialect=ansi", "-" },
+  args = { "fix", "-" },
   stdin = true,
   cwd = util.root_file({
     ".sqlfluff",
@@ -16,5 +16,5 @@ return {
     "setup.cfg",
     "tox.ini",
   }),
-  require_cwd = false,
+  require_cwd = true,
 }


### PR DESCRIPTION
Assuming the ANSI dialect may lead to parsing errors when using syntax specific to some dialect, so it shouldn't be the default. Therefore, a config is mandatory, to select the dialect.

We can't just update the exit codes because `sqlfluff` straight up refuses to format with some erros. For instance, I was getting:

```
WARNING    Fixes for LT09 not applied, as it would result in an unparsable file. Please report this as a bug with a minimal query which demonstrates this warning.                                                                             
WARNING    One fix for LT09 not applied, it would re-cause the same error.                                                                                                                                                                     
```

When running `sqlfluff fix --dialect=ansi -` for a given query (on the command line).