### PR TITLE
refactor: use vim.system

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,7 +50,6 @@ jobs:
     strategy:
       matrix:
         include:
-          - nvim_tag: v0.9.4
           - nvim_tag: v0.10.0
 
     name: Run tests

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Lightweight yet powerful formatter plugin for Neovim
 
 ## Requirements
 
-- Neovim 0.9+ (for older versions, use a [nvim-0.x branch](https://github.com/stevearc/conform.nvim/branches))
+- Neovim 0.10+ (for older versions, use a [nvim-0.x branch](https://github.com/stevearc/conform.nvim/branches))
 
 ## Features
 

--- a/lua/conform/errors.lua
+++ b/lua/conform/errors.lua
@@ -7,10 +7,6 @@ local M = {}
 
 ---@enum conform.ERROR_CODE
 M.ERROR_CODE = {
-  -- Command was passed invalid arguments
-  INVALID_ARGS = 1,
-  -- Command was not executable
-  NOT_EXECUTABLE = 2,
   -- Error occurred during when calling vim.system
   VIM_SYSTEM = 3,
   -- Command timed out during execution
@@ -39,10 +35,7 @@ end
 ---@param code conform.ERROR_CODE
 ---@return boolean
 M.is_execution_error = function(code)
-  return code == M.ERROR_CODE.RUNTIME
-    or code == M.ERROR_CODE.NOT_EXECUTABLE
-    or code == M.ERROR_CODE.INVALID_ARGS
-    or code == M.ERROR_CODE.VIM_SYSTEM
+  return code == M.ERROR_CODE.RUNTIME or code == M.ERROR_CODE.VIM_SYSTEM
 end
 
 ---@param err1? conform.Error

--- a/lua/conform/errors.lua
+++ b/lua/conform/errors.lua
@@ -11,8 +11,8 @@ M.ERROR_CODE = {
   INVALID_ARGS = 1,
   -- Command was not executable
   NOT_EXECUTABLE = 2,
-  -- Error occurred during when calling jobstart
-  JOBSTART = 3,
+  -- Error occurred during when calling vim.system
+  VIM_SYSTEM = 3,
   -- Command timed out during execution
   TIMEOUT = 4,
   -- Command was pre-empted by another call to format
@@ -42,7 +42,7 @@ M.is_execution_error = function(code)
   return code == M.ERROR_CODE.RUNTIME
     or code == M.ERROR_CODE.NOT_EXECUTABLE
     or code == M.ERROR_CODE.INVALID_ARGS
-    or code == M.ERROR_CODE.JOBSTART
+    or code == M.ERROR_CODE.VIM_SYSTEM
 end
 
 ---@param err1? conform.Error

--- a/lua/conform/init.lua
+++ b/lua/conform/init.lua
@@ -52,8 +52,8 @@ end
 
 ---@param opts? conform.setupOpts
 M.setup = function(opts)
-  if vim.fn.has("nvim-0.9") == 0 then
-    notify("conform.nvim requires Neovim 0.9+", vim.log.levels.ERROR)
+  if vim.fn.has("nvim-0.10") == 0 then
+    notify("conform.nvim requires Neovim 0.10+", vim.log.levels.ERROR)
     return
   end
   opts = opts or {}

--- a/lua/conform/runner.lua
+++ b/lua/conform/runner.lua
@@ -53,8 +53,8 @@ M.build_cmd = function(formatter_name, ctx, config)
       :gsub("$RELATIVE_FILEPATH", compute_relative_filepath)
       :gsub("$EXTENSION", ctx.filename:match(".*(%..*)$") or "")
     return {
-      vim.o.shell,
-      vim.o.shellcmdflag,
+      vim.split(vim.o.shell, " "),
+      vim.split(vim.o.shellcmdflag, " "),
       string.format("{%s %s}", command, interpolated),
     }
   else

--- a/lua/conform/runner.lua
+++ b/lua/conform/runner.lua
@@ -52,11 +52,7 @@ M.build_cmd = function(formatter_name, ctx, config)
       :gsub("$DIRNAME", ctx.dirname)
       :gsub("$RELATIVE_FILEPATH", compute_relative_filepath)
       :gsub("$EXTENSION", ctx.filename:match(".*(%..*)$") or "")
-    return {
-      vim.split(vim.o.shell, " "),
-      vim.split(vim.o.shellcmdflag, " "),
-      string.format("{%s %s}", command, interpolated),
-    }
+    return util.shell_build_argv(command .. " " .. interpolated)
   else
     local cmd = { command }
     for _, v in ipairs(args) do

--- a/lua/conform/runner.lua
+++ b/lua/conform/runner.lua
@@ -436,17 +436,6 @@ local function run_formatter(bufnr, formatter, config, ctx, input_lines, opts, c
     return
   end
   jid = job_or_err.pid
-  if jid == 0 then
-    callback({
-      code = errors.ERROR_CODE.INVALID_ARGS,
-      message = string.format("Formatter '%s' invalid arguments", formatter.name),
-    })
-  elseif jid == -1 then
-    callback({
-      code = errors.ERROR_CODE.NOT_EXECUTABLE,
-      message = string.format("Formatter '%s' command is not executable", formatter.name),
-    })
-  end
   if opts.exclusive then
     vim.b[bufnr].conform_jid = jid
   end

--- a/lua/conform/runner.lua
+++ b/lua/conform/runner.lua
@@ -20,6 +20,10 @@ M.build_cmd = function(formatter_name, ctx, config)
   if type(command) == "function" then
     command = command(config, ctx)
   end
+  local exepath = vim.fn.exepath(command)
+  if exepath ~= "" then
+    command = exepath
+  end
   ---@type string|string[]
   local args = {}
   if ctx.range and config.range_args then

--- a/lua/conform/runner.lua
+++ b/lua/conform/runner.lua
@@ -518,7 +518,7 @@ M.format_async = function(bufnr, formatters, range, opts, callback)
   -- kill previous jobs for buffer
   local prev_jid = vim.b[bufnr].conform_jid
   if prev_jid and opts.exclusive then
-    if vim.fn.jobstop(prev_jid) == 1 then
+    if uv.kill(prev_jid) == 0 then
       log.info("Canceled previous format job for %s", vim.api.nvim_buf_get_name(bufnr))
     end
   end
@@ -610,7 +610,7 @@ M.format_sync = function(bufnr, formatters, timeout_ms, range, opts)
   -- kill previous jobs for buffer
   local prev_jid = vim.b[bufnr].conform_jid
   if prev_jid and opts.exclusive then
-    if vim.fn.jobstop(prev_jid) == 1 then
+    if uv.kill(prev_jid) == 0 then
       log.info("Canceled previous format job for %s", vim.api.nvim_buf_get_name(bufnr))
     end
   end
@@ -682,7 +682,7 @@ M.format_lines_sync = function(bufnr, formatters, timeout_ms, range, input_lines
 
     if not wait_result then
       if jid then
-        vim.fn.jobstop(jid)
+        uv.kill(jid)
       end
       if wait_reason == -1 then
         return errors.coalesce(final_err, {

--- a/lua/conform/util.lua
+++ b/lua/conform/util.lua
@@ -1,3 +1,5 @@
+local ffi = require("ffi")
+
 local M = {}
 
 ---Find a command in node_modules
@@ -207,6 +209,25 @@ M.parse_rust_edition = function(dir)
       end
     end
   end
+end
+
+ffi.cdef([[
+char** shell_build_argv(const char* cmd, const char* extra_args);
+void shell_free_argv(char** argv);
+]])
+
+---@param cmd string
+---@return string[]
+M.shell_build_argv = function(cmd)
+  local cargv = ffi.C.shell_build_argv(cmd, nil)
+  local argv = {}
+  local i = 0
+  while cargv[i] ~= nil do
+    table.insert(argv, ffi.string(cargv[i]))
+    i = i + 1
+  end
+  ffi.C.shell_free_argv(cargv)
+  return argv
 end
 
 return M

--- a/tests/runner_spec.lua
+++ b/tests/runner_spec.lua
@@ -8,8 +8,8 @@ local util = require("conform.util")
 ---@return string[]
 local function shell(cmd)
   return {
-    vim.o.shell,
-    vim.o.shellcmdflag,
+    vim.split(vim.o.shell, " "),
+    vim.split(vim.o.shellcmdflag, " "),
     string.format("{%s}", cmd),
   }
 end

--- a/tests/runner_spec.lua
+++ b/tests/runner_spec.lua
@@ -4,16 +4,6 @@ local runner = require("conform.runner")
 local test_util = require("tests.test_util")
 local util = require("conform.util")
 
----@param cmd string
----@return string[]
-local function shell(cmd)
-  return {
-    vim.split(vim.o.shell, " "),
-    vim.split(vim.o.shellcmdflag, " "),
-    string.format("{%s}", cmd),
-  }
-end
-
 describe("runner", function()
   local OUTPUT_FILE
   local CLEANUP_FILES = {}
@@ -178,7 +168,7 @@ describe("runner", function()
       local config = assert(conform.get_formatter_config("test"))
       local ctx = runner.build_context(0, config)
       local cmd = runner.build_cmd("", ctx, config)
-      assert.are.same(shell(vim.fn.exepath("echo") .. " | patch"), cmd)
+      assert.are.same(util.shell_build_argv(vim.fn.exepath("echo") .. " | patch"), cmd)
     end)
   end)
 

--- a/tests/runner_spec.lua
+++ b/tests/runner_spec.lua
@@ -121,7 +121,7 @@ describe("runner", function()
       local config = assert(conform.get_formatter_config("test"))
       local ctx = runner.build_context(0, config)
       local cmd = runner.build_cmd("", ctx, config)
-      assert.are.same({ "echo", vim.api.nvim_buf_get_name(bufnr) }, cmd)
+      assert.are.same({ vim.fn.exepath("echo"), vim.api.nvim_buf_get_name(bufnr) }, cmd)
     end)
 
     it("replaces $DIRNAME in args", function()
@@ -135,7 +135,10 @@ describe("runner", function()
       local config = assert(conform.get_formatter_config("test"))
       local ctx = runner.build_context(0, config)
       local cmd = runner.build_cmd("", ctx, config)
-      assert.are.same({ "echo", vim.fs.dirname(vim.api.nvim_buf_get_name(bufnr)) }, cmd)
+      assert.are.same(
+        { vim.fn.exepath("echo"), vim.fs.dirname(vim.api.nvim_buf_get_name(bufnr)) },
+        cmd
+      )
     end)
 
     it("resolves arg function", function()
@@ -150,7 +153,7 @@ describe("runner", function()
       local config = assert(conform.get_formatter_config("test"))
       local ctx = runner.build_context(0, config)
       local cmd = runner.build_cmd("", ctx, config)
-      assert.are.same({ "echo", "--stdin" }, cmd)
+      assert.are.same({ vim.fn.exepath("echo"), "--stdin" }, cmd)
     end)
 
     it("replaces $FILENAME in string args", function()
@@ -164,7 +167,10 @@ describe("runner", function()
       local config = assert(conform.get_formatter_config("test"))
       local ctx = runner.build_context(0, config)
       local cmd = runner.build_cmd("", ctx, config)
-      assert.equal("echo " .. vim.api.nvim_buf_get_name(bufnr) .. " | patch", cmd)
+      assert.equal(
+        vim.fn.exepath("echo") .. " " .. vim.api.nvim_buf_get_name(bufnr) .. " | patch",
+        cmd
+      )
     end)
 
     it("replaces $DIRNAME in string args", function()
@@ -178,7 +184,13 @@ describe("runner", function()
       local config = assert(conform.get_formatter_config("test"))
       local ctx = runner.build_context(0, config)
       local cmd = runner.build_cmd("", ctx, config)
-      assert.equal("echo " .. vim.fs.dirname(vim.api.nvim_buf_get_name(bufnr)) .. " | patch", cmd)
+      assert.equal(
+        vim.fn.exepath("echo")
+          .. " "
+          .. vim.fs.dirname(vim.api.nvim_buf_get_name(bufnr))
+          .. " | patch",
+        cmd
+      )
     end)
 
     it("resolves arg function with string results", function()
@@ -193,7 +205,7 @@ describe("runner", function()
       local config = assert(conform.get_formatter_config("test"))
       local ctx = runner.build_context(0, config)
       local cmd = runner.build_cmd("", ctx, config)
-      assert.equal("echo | patch", cmd)
+      assert.equal(vim.fn.exepath("echo") .. " | patch", cmd)
     end)
   end)
 

--- a/tests/runner_spec.lua
+++ b/tests/runner_spec.lua
@@ -4,6 +4,16 @@ local runner = require("conform.runner")
 local test_util = require("tests.test_util")
 local util = require("conform.util")
 
+---@param cmd string
+---@return string[]
+local function shell(cmd)
+  return {
+    vim.o.shell,
+    vim.o.shellcmdflag,
+    string.format("{%s}", cmd),
+  }
+end
+
 describe("runner", function()
   local OUTPUT_FILE
   local CLEANUP_FILES = {}
@@ -167,8 +177,8 @@ describe("runner", function()
       local config = assert(conform.get_formatter_config("test"))
       local ctx = runner.build_context(0, config)
       local cmd = runner.build_cmd("", ctx, config)
-      assert.equal(
-        vim.fn.exepath("echo") .. " " .. vim.api.nvim_buf_get_name(bufnr) .. " | patch",
+      assert.are.same(
+        shell(vim.fn.exepath("echo") .. " " .. vim.api.nvim_buf_get_name(bufnr) .. " | patch"),
         cmd
       )
     end)
@@ -184,11 +194,13 @@ describe("runner", function()
       local config = assert(conform.get_formatter_config("test"))
       local ctx = runner.build_context(0, config)
       local cmd = runner.build_cmd("", ctx, config)
-      assert.equal(
-        vim.fn.exepath("echo")
-          .. " "
-          .. vim.fs.dirname(vim.api.nvim_buf_get_name(bufnr))
-          .. " | patch",
+      assert.are.same(
+        shell(
+          vim.fn.exepath("echo")
+            .. " "
+            .. vim.fs.dirname(vim.api.nvim_buf_get_name(bufnr))
+            .. " | patch"
+        ),
         cmd
       )
     end)
@@ -205,7 +217,7 @@ describe("runner", function()
       local config = assert(conform.get_formatter_config("test"))
       local ctx = runner.build_context(0, config)
       local cmd = runner.build_cmd("", ctx, config)
-      assert.equal(vim.fn.exepath("echo") .. " | patch", cmd)
+      assert.are.same(shell(vim.fn.exepath("echo") .. " | patch"), cmd)
     end)
   end)
 

--- a/tests/runner_spec.lua
+++ b/tests/runner_spec.lua
@@ -166,45 +166,6 @@ describe("runner", function()
       assert.are.same({ vim.fn.exepath("echo"), "--stdin" }, cmd)
     end)
 
-    it("replaces $FILENAME in string args", function()
-      vim.cmd.edit({ args = { "README.md" } })
-      local bufnr = vim.api.nvim_get_current_buf()
-      conform.formatters.test = {
-        meta = { url = "", description = "" },
-        command = "echo",
-        args = "$FILENAME | patch",
-      }
-      local config = assert(conform.get_formatter_config("test"))
-      local ctx = runner.build_context(0, config)
-      local cmd = runner.build_cmd("", ctx, config)
-      assert.are.same(
-        shell(vim.fn.exepath("echo") .. " " .. vim.api.nvim_buf_get_name(bufnr) .. " | patch"),
-        cmd
-      )
-    end)
-
-    it("replaces $DIRNAME in string args", function()
-      vim.cmd.edit({ args = { "README.md" } })
-      local bufnr = vim.api.nvim_get_current_buf()
-      conform.formatters.test = {
-        meta = { url = "", description = "" },
-        command = "echo",
-        args = "$DIRNAME | patch",
-      }
-      local config = assert(conform.get_formatter_config("test"))
-      local ctx = runner.build_context(0, config)
-      local cmd = runner.build_cmd("", ctx, config)
-      assert.are.same(
-        shell(
-          vim.fn.exepath("echo")
-            .. " "
-            .. vim.fs.dirname(vim.api.nvim_buf_get_name(bufnr))
-            .. " | patch"
-        ),
-        cmd
-      )
-    end)
-
     it("resolves arg function with string results", function()
       vim.cmd.edit({ args = { "README.md" } })
       conform.formatters.test = {

--- a/tests/runner_spec.lua
+++ b/tests/runner_spec.lua
@@ -395,5 +395,13 @@ print("a")
         assert.are.same({ "a", "d", "c" }, vim.api.nvim_buf_get_lines(0, 0, -1, false))
       end)
     end)
+
+    it("can run the format command in the shell", function()
+      conform.formatters.test = {
+        command = "echo",
+        args = '-e "world\nhello" | sort',
+      }
+      run_formatter_test("", "hello\nworld")
+    end)
   end)
 end)

--- a/tests/util_spec.lua
+++ b/tests/util_spec.lua
@@ -1,0 +1,72 @@
+local test_util = require("tests.test_util")
+local util = require("conform.util")
+
+describe("util", function()
+  local shell = vim.o.shell
+  local shellcmdflag = vim.o.shellcmdflag
+  local shellxescape = vim.o.shellxescape
+  local shellxquote = vim.o.shellxquote
+  after_each(function()
+    test_util.reset_editor()
+    vim.o.shell = shell
+    vim.o.shellcmdflag = shellcmdflag
+    vim.o.shellxescape = shellxescape
+    vim.o.shellxquote = shellxquote
+  end)
+
+  describe("shell_build_argv", function()
+    it("builds simple command", function()
+      vim.o.shell = "/bin/bash"
+      vim.o.shellcmdflag = "-c"
+      vim.o.shellxescape = ""
+      vim.o.shellxquote = ""
+      local argv = util.shell_build_argv("echo hello")
+      assert.are_same({ "/bin/bash", "-c", "echo hello" }, argv)
+    end)
+
+    it("handles shell arguments", function()
+      vim.o.shell = "/bin/bash -f"
+      vim.o.shellcmdflag = "-c"
+      vim.o.shellxescape = ""
+      vim.o.shellxquote = ""
+      local argv = util.shell_build_argv("echo hello")
+      assert.are_same({ "/bin/bash", "-f", "-c", "echo hello" }, argv)
+    end)
+
+    it("handles shell with spaces", function()
+      vim.o.shell = '"c:\\program files\\unix\\sh.exe"'
+      vim.o.shellcmdflag = "-c"
+      vim.o.shellxescape = ""
+      vim.o.shellxquote = ""
+      local argv = util.shell_build_argv("echo hello")
+      assert.are_same({ "c:\\program files\\unix\\sh.exe", "-c", "echo hello" }, argv)
+    end)
+
+    it("handles shell with spaces and args", function()
+      vim.o.shell = '"c:\\program files\\unix\\sh.exe" -f'
+      vim.o.shellcmdflag = "-c"
+      vim.o.shellxescape = ""
+      vim.o.shellxquote = ""
+      local argv = util.shell_build_argv("echo hello")
+      assert.are_same({ "c:\\program files\\unix\\sh.exe", "-f", "-c", "echo hello" }, argv)
+    end)
+
+    it("applies shellxquote", function()
+      vim.o.shell = "/bin/bash"
+      vim.o.shellcmdflag = "-c"
+      vim.o.shellxescape = ""
+      vim.o.shellxquote = "'"
+      local argv = util.shell_build_argv("echo hello")
+      assert.are_same({ "/bin/bash", "-c", "'echo hello'" }, argv)
+    end)
+
+    it("uses shellxescape", function()
+      vim.o.shell = "/bin/bash"
+      vim.o.shellcmdflag = "-c"
+      vim.o.shellxescape = "el"
+      vim.o.shellxquote = "("
+      local argv = util.shell_build_argv("echo hello")
+      assert.are_same({ "/bin/bash", "-c", "(^echo h^e^l^lo)" }, argv)
+    end)
+  end)
+end)


### PR DESCRIPTION
Use `vim.system` instead of `vim.fn.jobstart` for performance gains (#191)

`black` before:
![black-before](https://github.com/user-attachments/assets/b3330774-4f2b-4f32-bdea-7346ba3be5b6)
`black` after:
![black-after](https://github.com/user-attachments/assets/3f191e3d-e342-43ae-ab76-8362db3557a0)
