### PR TITLE
Update deno_fmt.lua to allow esmodule extension

### DIFF
--- a/lua/conform/formatters/deno_fmt.lua
+++ b/lua/conform/formatters/deno_fmt.lua
@@ -4,6 +4,7 @@ local extensions = {
   json = "json",
   jsonc = "jsonc",
   markdown = "md",
+  esmodule = "mjs",
   typescript = "ts",
   typescriptreact = "tsx",
 }


### PR DESCRIPTION
Adding the `.mjs` extension for Deno

https://docs.fileformat.com/web/mjs/