### PR TITLE
feat(zine): add superhtml and ziggy support

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,6 +335,7 @@ You can view this list in vim with `:help conform-formatters`
 - [styler](https://github.com/devOpifex/r.nvim) - R formatter and linter.
 - [stylish-haskell](https://github.com/haskell/stylish-haskell) - Haskell code prettifier.
 - [stylua](https://github.com/JohnnyMorganz/StyLua) - An opinionated code formatter for Lua.
+- [superhtml](https://github.com/kristoff-it/superhtml) - HTML Language Server and Templating Language Library
 - [swift_format](https://github.com/apple/swift-format) - Swift formatter from apple. Requires building from source with `swift build`.
 - [swiftformat](https://github.com/nicklockwood/SwiftFormat) - SwiftFormat is a code library and command-line tool for reformatting `swift` code on macOS or Linux.
 - [swiftlint](https://github.com/realm/SwiftLint) - A tool to enforce Swift style and conventions.

--- a/README.md
+++ b/README.md
@@ -362,6 +362,7 @@ You can view this list in vim with `:help conform-formatters`
 - [yew-fmt](https://github.com/schvv31n/yew-fmt) - Code formatter for the Yew framework.
 - [yq](https://github.com/mikefarah/yq) - YAML/JSON processor
 - [zigfmt](https://github.com/ziglang/zig) - Reformat Zig source into canonical form.
+- [ziggy](https://github.com/kristoff-it/ziggy) - A data serialization language for expressing clear API messages, config files, etc.
 - [zprint](https://github.com/kkinnear/zprint) - Formatter for Clojure and EDN.
 <!-- /FORMATTERS -->
 

--- a/doc/conform.txt
+++ b/doc/conform.txt
@@ -497,6 +497,7 @@ FORMATTERS                                                    *conform-formatter
 `yew-fmt` - Code formatter for the Yew framework.
 `yq` - YAML/JSON processor
 `zigfmt` - Reformat Zig source into canonical form.
+`ziggy` - A data serialization language for expressing clear API messages, config files, etc.
 `zprint` - Formatter for Clojure and EDN.
 
 ================================================================================

--- a/doc/conform.txt
+++ b/doc/conform.txt
@@ -461,6 +461,7 @@ FORMATTERS                                                    *conform-formatter
 `styler` - R formatter and linter.
 `stylish-haskell` - Haskell code prettifier.
 `stylua` - An opinionated code formatter for Lua.
+`superhtml` - HTML Language Server and Templating Language Library
 `swift_format` - Swift formatter from apple. Requires building from source with
                `swift build`.
 `swiftformat` - SwiftFormat is a code library and command-line tool for

--- a/lua/conform/formatters/superhtml.lua
+++ b/lua/conform/formatters/superhtml.lua
@@ -2,7 +2,7 @@
 return {
   meta = {
     url = "https://github.com/kristoff-it/superhtml",
-    description = "HTML Language Server and Templating Language Library",
+    description = "HTML Language Server and Templating Language Library.",
   },
   command = "superhtml",
   args = { "fmt", "--stdin" },

--- a/lua/conform/formatters/superhtml.lua
+++ b/lua/conform/formatters/superhtml.lua
@@ -1,0 +1,9 @@
+---@type conform.FileFormatterConfig
+return {
+  meta = {
+    url = "https://github.com/kristoff-it/superhtml",
+    description = "HTML Language Server and Templating Language Library",
+  },
+  command = "superhtml",
+  args = { "fmt", "--stdin" },
+}

--- a/lua/conform/formatters/ziggy.lua
+++ b/lua/conform/formatters/ziggy.lua
@@ -1,0 +1,9 @@
+---@type conform.FileFormatterConfig
+return {
+  meta = {
+    url = "https://github.com/kristoff-it/ziggy",
+    description = "A data serialization language for expressing clear API messages, config files, etc.",
+  },
+  command = "ziggy",
+  args = { "fmt", "--stdin" },
+}

--- a/lua/conform/formatters/ziggy_schema.lua
+++ b/lua/conform/formatters/ziggy_schema.lua
@@ -1,0 +1,9 @@
+---@type conform.FileFormatterConfig
+return {
+  meta = {
+    url = "https://github.com/kristoff-it/ziggy",
+    description = "A data serialization language for expressing clear API messages, config files, etc.",
+  },
+  command = "ziggy",
+  args = { "fmt", "--stdin-schema" },
+}


### PR DESCRIPTION
Add support for formatters used (and created) by the zine static site generator
project:

- [Zine](https://github.com/kristoff-it/zine)
- [SuperHTML](https://github.com/kristoff-it/superhtml)
- [Ziggy](https://github.com/kristoff-it/ziggy)
