### PR TITLE
Add missing deno_fmt extensions

### DIFF
--- a/lua/conform/formatters/deno_fmt.lua
+++ b/lua/conform/formatters/deno_fmt.lua
@@ -1,6 +1,15 @@
+local conform = require("conform")
 local log = require("conform.log")
 
-local extensions = {
+-- Requires `--unstable-component` flag or
+-- `"unstable": ["fmt-component]` config option.
+-- https://docs.deno.com/runtime/reference/cli/formatter/#formatting-options-unstable-component
+local unstable_extensions = {
+  astro = "astro",
+  svelte = "svelte",
+  vue = "vue",
+}
+local extensions = vim.tbl_extend("keep", {
   css = "css",
   esmodule = "mjs",
   html = "html",
@@ -15,12 +24,8 @@ local extensions = {
   typescript = "ts",
   typescriptreact = "tsx",
   yaml = "yml",
-  -- Requires `--unstable-component` flag or
-  -- `"unstable": ["fmt-component]` config option.
-  astro = "astro",
-  svelte = "svelte",
-  vue = "vue",
-}
+}, unstable_extensions)
+
 ---@type conform.FileFormatterConfig
 return {
   meta = {
@@ -31,10 +36,13 @@ return {
   args = function(self, ctx)
     local extension = extensions[vim.bo[ctx.buf].filetype]
 
-    -- TODO: How do I check if the user has passed in `--unstable-component` with e.g. `append_args` in their config?
-    print("self: " .. vim.inspect(self))
-    print("ctx: " .. vim.inspect(ctx))
-    if true then
+    if
+      vim.tbl_get(unstable_extensions, extension)
+      and not vim.list_contains(
+        vim.tbl_get(conform.formatters, "deno_fmt", "append_args") or {},
+        "--unstable-component"
+      )
+    then
       log.warn(
         "You are trying to format an unstable file type (."
           .. extension

--- a/lua/conform/formatters/deno_fmt.lua
+++ b/lua/conform/formatters/deno_fmt.lua
@@ -11,7 +11,6 @@ local unstable_extensions = {
 }
 local extensions = vim.tbl_extend("keep", {
   css = "css",
-  esmodule = "mjs",
   html = "html",
   javascript = "js",
   javascriptreact = "jsx",

--- a/lua/conform/formatters/deno_fmt.lua
+++ b/lua/conform/formatters/deno_fmt.lua
@@ -38,7 +38,7 @@ return {
       log.warn(
         "You are trying to format an unstable file type (."
           .. extension
-          .. ") without the corresponding `--unstable-component` flag. Add the flag to format the code. See the Deno documentation for more information: https://docs.deno.com/runtime/reference/cli/formatter/#formatting-options-unstable-component"
+          .. ") without the corresponding `--unstable-component` flag. Add the flag to `append_args` to format your code. See the Deno documentation for more information: https://docs.deno.com/runtime/reference/cli/formatter/#formatting-options-unstable-component"
       )
     end
 

--- a/lua/conform/formatters/deno_fmt.lua
+++ b/lua/conform/formatters/deno_fmt.lua
@@ -13,6 +13,11 @@ local extensions = {
   typescript = "ts",
   typescriptreact = "tsx",
   yaml = "yml",
+  -- Requires `--unstable-component` flag or
+  -- `"unstable": ["fmt-component]` config option.
+  astro = "astro",
+  svelte = "svelte",
+  vue = "vue",
 }
 ---@type conform.FileFormatterConfig
 return {

--- a/lua/conform/formatters/deno_fmt.lua
+++ b/lua/conform/formatters/deno_fmt.lua
@@ -43,16 +43,15 @@ return {
     }
 
     if
-      vim.tbl_get(unstable_extensions, extension)
+      unstable_extensions[extension]
       and not vim.list_contains(
         vim.tbl_get(conform.formatters, "deno_fmt", "append_args") or {},
         "--unstable-component"
       )
     then
       log.info(
-        "Adding `--unstable-component` to enable formatting of ."
-          .. extension
-          .. " files. See the Deno documentation for more information: https://docs.deno.com/runtime/reference/cli/formatter/#formatting-options-unstable-component"
+        "Adding `--unstable-component` to enable formatting of .%s files. See the Deno documentation for more information: https://docs.deno.com/runtime/reference/cli/formatter/#formatting-options-unstable-component",
+        extension
       )
       formatter_args = vim.list_extend(formatter_args, { "--unstable-component" })
     end

--- a/lua/conform/formatters/deno_fmt.lua
+++ b/lua/conform/formatters/deno_fmt.lua
@@ -42,13 +42,7 @@ return {
       extension,
     }
 
-    if
-      unstable_extensions[extension]
-      and not vim.list_contains(
-        vim.tbl_get(conform.formatters, "deno_fmt", "append_args") or {},
-        "--unstable-component"
-      )
-    then
+    if unstable_extensions[extension] then
       log.info(
         "Adding `--unstable-component` to enable formatting of .%s files. See the Deno documentation for more information: https://docs.deno.com/runtime/reference/cli/formatter/#formatting-options-unstable-component",
         extension

--- a/lua/conform/formatters/deno_fmt.lua
+++ b/lua/conform/formatters/deno_fmt.lua
@@ -35,6 +35,12 @@ return {
   command = "deno",
   args = function(self, ctx)
     local extension = extensions[vim.bo[ctx.buf].filetype]
+    local formatter_args = {
+      "fmt",
+      "-",
+      "--ext",
+      extension,
+    }
 
     if
       vim.tbl_get(unstable_extensions, extension)
@@ -43,18 +49,14 @@ return {
         "--unstable-component"
       )
     then
-      log.warn(
-        "You are trying to format an unstable file type (."
+      log.info(
+        "Adding `--unstable-component` to enable formatting of ."
           .. extension
-          .. ") without the corresponding `--unstable-component` flag. Add the flag to `append_args` to format your code. See the Deno documentation for more information: https://docs.deno.com/runtime/reference/cli/formatter/#formatting-options-unstable-component"
+          .. " files. See the Deno documentation for more information: https://docs.deno.com/runtime/reference/cli/formatter/#formatting-options-unstable-component"
       )
+      formatter_args = vim.list_extend(formatter_args, { "--unstable-component" })
     end
 
-    return {
-      "fmt",
-      "-",
-      "--ext",
-      extension,
-    }
+    return formatter_args
   end,
 }

--- a/lua/conform/formatters/deno_fmt.lua
+++ b/lua/conform/formatters/deno_fmt.lua
@@ -1,10 +1,10 @@
 local extensions = {
+  esmodule = "mjs",
   javascript = "js",
   javascriptreact = "jsx",
   json = "json",
   jsonc = "jsonc",
   markdown = "md",
-  esmodule = "mjs",
   typescript = "ts",
   typescriptreact = "tsx",
 }

--- a/lua/conform/formatters/deno_fmt.lua
+++ b/lua/conform/formatters/deno_fmt.lua
@@ -1,3 +1,5 @@
+local log = require("conform.log")
+
 local extensions = {
   css = "css",
   esmodule = "mjs",
@@ -27,11 +29,24 @@ return {
   },
   command = "deno",
   args = function(self, ctx)
+    local extension = extensions[vim.bo[ctx.buf].filetype]
+
+    -- TODO: How do I check if the user has passed in `--unstable-component` with e.g. `append_args` in their config?
+    print("self: " .. vim.inspect(self))
+    print("ctx: " .. vim.inspect(ctx))
+    if true then
+      log.warn(
+        "You are trying to format an unstable file type (."
+          .. extension
+          .. ") without the corresponding `--unstable-component` flag. Add the flag to format the code. See the Deno documentation for more information: https://docs.deno.com/runtime/reference/cli/formatter/#formatting-options-unstable-component"
+      )
+    end
+
     return {
       "fmt",
       "-",
       "--ext",
-      extensions[vim.bo[ctx.buf].filetype],
+      extension,
     }
   end,
 }

--- a/lua/conform/formatters/deno_fmt.lua
+++ b/lua/conform/formatters/deno_fmt.lua
@@ -1,12 +1,18 @@
 local extensions = {
+  css = "css",
   esmodule = "mjs",
+  html = "html",
   javascript = "js",
   javascriptreact = "jsx",
   json = "json",
   jsonc = "jsonc",
+  less = "less",
   markdown = "md",
+  sass = "sass",
+  scss = "scss",
   typescript = "ts",
   typescriptreact = "tsx",
+  yaml = "yml",
 }
 ---@type conform.FileFormatterConfig
 return {

--- a/lua/conform/formatters/deno_fmt.lua
+++ b/lua/conform/formatters/deno_fmt.lua
@@ -1,4 +1,3 @@
-local conform = require("conform")
 local log = require("conform.log")
 
 -- Requires `--unstable-component` flag or
@@ -32,6 +31,9 @@ return {
     description = "Use [Deno](https://deno.land/) to format TypeScript, JavaScript/JSON and markdown.",
   },
   command = "deno",
+  cond = function(self, ctx)
+    return extensions[vim.bo[ctx.buf].filetype] ~= nil
+  end,
   args = function(self, ctx)
     local extension = extensions[vim.bo[ctx.buf].filetype]
     local formatter_args = {


### PR DESCRIPTION
I completed the `deno_fmt` extensions table with the [table of supported extensions in Deno's documentation](https://docs.deno.com/runtime/reference/cli/formatter/#supported-file-types). I added a couple of stable extensions that needed to be included.

Three unstable ones were also absent: Astro, Svelte, and Vue. These require the `--unstable-component` flag to work. If you don't provide the flag, the `deno fmt` command exists successfully (code 0) but does nothing.  Should the code here be refactored so that an info/warning/error message is logged if you format one of these files without the flag to improve debugging?

The [unstable-component flag documentation](https://docs.deno.com/runtime/reference/cli/formatter/#formatting-options-unstable-component) mentions that Angular files are supported, but to my knowledge, there are no `.angular` files. Does anyone know what this means?

Also, can I remove `esmodule` from the `extensions` table? A `.mjs` file returns `javascript` as its extension, so I think `esmodule` isn't a valid extension in Neovim.