### PR TITLE
feat: add `biome-lint`

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ You can view this list in vim with `:help conform-formatters`
 - [bicep](https://github.com/Azure/bicep) - Bicep is a Domain Specific Language (DSL) for deploying Azure resources declaratively.
 - [biome](https://github.com/biomejs/biome) - A toolchain for web projects, aimed to provide functionalities to maintain them.
 - [biome-check](https://github.com/biomejs/biome) - A toolchain for web projects, aimed to provide functionalities to maintain them.
+- [biome-lint](https://github.com/biomejs/biome) - A toolchain for web projects, aimed to provide functionalities to maintain them.
 - [black](https://github.com/psf/black) - The uncompromising Python code formatter.
 - [blade-formatter](https://github.com/shufo/blade-formatter) - An opinionated blade template formatter for Laravel that respects readability.
 - [blue](https://github.com/grantjenks/blue) - The slightly less uncompromising Python code formatter.

--- a/lua/conform/formatters/biome-lint.lua
+++ b/lua/conform/formatters/biome-lint.lua
@@ -1,0 +1,15 @@
+local util = require("conform.util")
+---@type conform.FileFormatterConfig
+return {
+  meta = {
+    url = "https://github.com/biomejs/biome",
+    description = "A toolchain for web projects, aimed to provide functionalities to maintain them.",
+  },
+  command = util.from_node_modules("biome"),
+  stdin = true,
+  args = { "lint", "--write", "--unsafe", "--stdin-file-path", "$FILENAME" },
+  cwd = util.root_file({
+    "biome.json",
+    "biome.jsonc",
+  }),
+}


### PR DESCRIPTION
Adding support for using biome lint command. It is mainly used for the tailwind sorting (and more) which is why the `--unsafe` flag is there.