### PR TITLE
chore: add example layout python for direnv

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,3 +1,3 @@
 export VIRTUAL_ENV=venv
-layout python
-python -c 'import pyparsing' 2> /dev/null || pip install -r scripts/requirements.txt
+layout python python3
+python -c 'import pyparsing' 2>/dev/null || pip install -r scripts/requirements.txt


### PR DESCRIPTION
added an example `.direnvrc` since i ran into this error

```
direnv: loading ~/dev/conform.nvim/.envrc
environment:860: python: command not found
direnv: Could not find python's version
./.envrc:2: pip: command not found
```