### PR TITLE
feat: add support for nginx-config-formatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,7 @@ You can view this list in vim with `:help conform-formatters`
 - [mdslw](https://github.com/razziel89/mdslw) - Prepare your markdown for easy diff'ing by adding line breaks after every sentence.
 - [mix](https://hexdocs.pm/mix/main/Mix.Tasks.Format.html) - Format Elixir files using the mix format command.
 - [mojo_format](https://docs.modular.com/mojo/cli/format) - Official Formatter for The Mojo Programming Language
+- [nginxfmt](https://github.com/slomkowski/nginx-config-formatter) - nginx config file formatter/beautifier written in Python with no additional dependencies. 
 - [nickel](https://nickel-lang.org/) - Code formatter for the Nickel programming language.
 - [nimpretty](https://github.com/nim-lang/nim) - nimpretty is a Nim source code beautifier that follows the official style guide.
 - [nixfmt](https://github.com/NixOS/nixfmt) - The official (but not yet stable) formatter for Nix code.

--- a/doc/conform.txt
+++ b/doc/conform.txt
@@ -394,6 +394,7 @@ FORMATTERS                                                    *conform-formatter
         every sentence.
 `mix` - Format Elixir files using the mix format command.
 `mojo_format` - Official Formatter for The Mojo Programming Language
+`nginxfmt` - nginx config file formatter/beautifier written in Python with no additional dependencies.
 `nickel` - Code formatter for the Nickel programming language.
 `nimpretty` - nimpretty is a Nim source code beautifier that follows the
             official style guide.

--- a/lua/conform/formatters/nginxfmt.lua
+++ b/lua/conform/formatters/nginxfmt.lua
@@ -1,0 +1,9 @@
+---@type conform.FileFormatterConfig
+return {
+  meta = {
+    url = "https://github.com/slomkowski/nginx-config-formatter",
+    description = "nginx config file formatter/beautifier written in Python with no additional dependencies.",
+  },
+  command = "nginxfmt",
+  args = { "-" },
+}


### PR DESCRIPTION
I saw nginx is very popular web server and is used widely, but there aren't any support for its config file now, so i add it. The config file without formatting is definitely a mess.

The doc is [here](https://github.com/slomkowski/nginx-config-formatter).