### PR TITLE
fix(prettier): update prettier formatter configuration to only trigger on projects with a .prettierrc file

### DIFF
--- a/lua/conform/formatters/prettier.lua
+++ b/lua/conform/formatters/prettier.lua
@@ -72,6 +72,5 @@ return {
     ".prettierrc.toml",
     "prettier.config.js",
     "prettier.config.cjs",
-    "package.json",
   }),
 }


### PR DESCRIPTION
This change updates the configuration of the Prettier formatter to prevent it from running based solely on the presence of a package.json file. Going forward, Prettier will only activate if a .prettierrc-type configuration file is present.

### Rationale
By limiting Prettier activation to projects with a dedicated Prettier configuration file, this change respects projects that use alternative formatters like dprint or eslint with custom plugins, ensuring that these tools can function without Prettier inadvertently overriding their formatting.

For example, templates such as create-effect-app, which use dprint and don’t generate a .prettierrc file, were previously impacted by Prettier, which introduced formatting inconsistencies (e.g., trailing commas) that conflicted with the project's style preferences and triggered linter errors.

### Impact
This update allows developers to use their preferred formatter consistently. In projects without a .prettierrc file, Prettier will no longer apply formatting, avoiding unnecessary changes and ensuring that the selected formatter is the sole tool enforcing code style.