### PR TITLE
Add support for Clojure standard-clj

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,6 +335,7 @@ You can view this list in vim with `:help conform-formatters`
 - [sqlfluff](https://github.com/sqlfluff/sqlfluff) - A modular SQL linter and auto-formatter with support for multiple dialects and templated code.
 - [sqlfmt](https://docs.sqlfmt.com) - sqlfmt formats your dbt SQL files so you don't have to. It is similar in nature to Black, gofmt, and rustfmt (but for SQL)
 - [squeeze_blanks](https://www.gnu.org/software/coreutils/manual/html_node/cat-invocation.html#cat-invocation) - Squeeze repeated blank lines into a single blank line via `cat -s`.
+- [standard-clj](https://github.com/oakmac/standard-clojure-style-js) - A JavaScript library to format Clojure code according to Standard Clojure Style.
 - [standardjs](https://standardjs.com) - JavaScript Standard style guide, linter, and formatter.
 - [standardrb](https://github.com/standardrb/standard) - Ruby's bikeshed-proof linter and formatter.
 - [stylelint](https://github.com/stylelint/stylelint) - A mighty CSS linter that helps you avoid errors and enforce conventions.

--- a/doc/conform.txt
+++ b/doc/conform.txt
@@ -462,6 +462,7 @@ FORMATTERS                                                    *conform-formatter
          in nature to Black, gofmt, and rustfmt (but for SQL)
 `squeeze_blanks` - Squeeze repeated blank lines into a single blank line via
                  `cat -s`.
+`standard-clj` - A JavaScript library to format Clojure code according to Standard Clojure Style.
 `standardjs` - JavaScript Standard style guide, linter, and formatter.
 `standardrb` - Ruby's bikeshed-proof linter and formatter.
 `stylelint` - A mighty CSS linter that helps you avoid errors and enforce

--- a/lua/conform/formatters/standard-clj.lua
+++ b/lua/conform/formatters/standard-clj.lua
@@ -1,0 +1,11 @@
+local util = require("conform.util")
+
+---@type conform.FileFormatterConfig
+return {
+  meta = {
+    url = "https://github.com/oakmac/standard-clojure-style-js",
+    description = "A JavaScript library to format Clojure code according to Standard Clojure Style.",
+  },
+  command = util.from_node_modules("standard-clj"),
+  args = { "fix", "-" },
+}


### PR DESCRIPTION
Adding support for [`standard-clj`](https://github.com/oakmac/standard-clojure-style-js).

The filename differs from the other standard linters, but wanted to preserve the command name.

(thanks for conform btw 🍻)