### PR TITLE
elixir mix: fix for current folder for execution

### DIFF
--- a/lua/conform/formatters/mix.lua
+++ b/lua/conform/formatters/mix.lua
@@ -7,7 +7,6 @@ return {
   command = "mix",
   args = { "format", "--stdin-filename", "$FILENAME", "-" },
   cwd = require("conform.util").root_file({
-    ".formatter.exs",
     "mix.exs",
   }),
 }


### PR DESCRIPTION
the current folder should be the project folder. There could be per-subfolder .formatter.exs files but you're not meant to run the formatter from such folders.

I ran into this exact issue:
https://elixirforum.com/t/formatter-error-in-phoenix-migrations-cant-find-ecto-sql/28764/10

This issue also happened in other editors, as can be seen in the link. The previous behavior would work fine if there was no .formatter.exs in subfolders or if these didn't rely on dependencies provided by the project-level mix.exs.

I also checked the documentation regarding the elixir formatting task:
https://hexdocs.pm/mix/1.12/Mix.Tasks.Format.html

In that documentation it's written:

```markdown
. If such option is not yet available in your editor of choice, adding the required integration is usually a matter of invoking:

    cd $project && mix format $file

where $file refers to the current file and $project is the root of your project.
```

The root of the project would be where the mix.exs is, but again there can be .formatter.exs files in subfolders.