### PR TITLE
fix(stylelint): support for ignored files, node_modules, and cwd

### DIFF
--- a/lua/conform/formatters/stylelint.lua
+++ b/lua/conform/formatters/stylelint.lua
@@ -1,11 +1,15 @@
+local util = require("conform.util")
 ---@type conform.FileFormatterConfig
 return {
   meta = {
     url = "https://github.com/stylelint/stylelint",
     description = "A mighty CSS linter that helps you avoid errors and enforce conventions.",
   },
-  command = "stylelint",
-  args = { "--stdin", "--fix" },
+  command = util.from_node_modules("stylelint"),
+  args = { "--stdin", "--stdin-filename", "$FILENAME", "--fix" },
   exit_codes = { 0, 2 }, -- code 2 is given when trying file includees some non-autofixable errors
   stdin = true,
+  cwd = util.root_file({
+    "package.json",
+  }),
 }


### PR DESCRIPTION
I've been using the stylelint formatter and noticed a few things that I've attempted to fix:

1. The version I installed from mason was always getting used even though stylelint was available via the file's relative `node_modules` directory. I changed the command to use `utils.from_node_modules` to fix this.
2. If I opened a CSS file that had a stylelint config in one of its parent directories from a directory without a stylelint config, I would get a missing configuration error. I'm not sure if I did this right but I added the same `cwd` configuration that `eslint_d` has and that seems to have fixed it.
3. CSS files that had a stylelint config but were being ignored by stylelint were still getting formatted by conform. I've added `--stdin-filename` to the args to fix this.