### PR TITLE
Rename awk formatter to gawk

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ You can view this list in vim with `:help conform-formatters`
 - [autocorrect](https://github.com/huacnlee/autocorrect) - A linter and formatter to help you to improve copywriting, correct spaces, words, and punctuations between CJK.
 - [autoflake](https://github.com/PyCQA/autoflake) - Removes unused imports and unused variables as reported by pyflakes.
 - [autopep8](https://github.com/hhatto/autopep8) - A tool that automatically formats Python code to conform to the PEP 8 style guide.
-- [gawk](https://www.gnu.org/software/gawk/manual/gawk.html) - Format awk programs with gawk
+- [gawk](https://www.gnu.org/software/gawk/manual/gawk.html) - Format awk programs with gawk.
 - [bean-format](https://beancount.github.io/docs/running_beancount_and_generating_reports.html#bean-format) - Reformat Beancount files to right-align all the numbers at the same, minimal column.
 - [beautysh](https://github.com/lovesegfault/beautysh) - A Bash beautifier for the masses.
 - [bibtex-tidy](https://github.com/FlamingTempura/bibtex-tidy) - Cleaner and Formatter for BibTeX files.

--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ You can view this list in vim with `:help conform-formatters`
 - [autocorrect](https://github.com/huacnlee/autocorrect) - A linter and formatter to help you to improve copywriting, correct spaces, words, and punctuations between CJK.
 - [autoflake](https://github.com/PyCQA/autoflake) - Removes unused imports and unused variables as reported by pyflakes.
 - [autopep8](https://github.com/hhatto/autopep8) - A tool that automatically formats Python code to conform to the PEP 8 style guide.
-- [awk](https://www.gnu.org/software/gawk/manual/gawk.html) - Format awk programs with awk
+- [gawk](https://www.gnu.org/software/gawk/manual/gawk.html) - Format awk programs with gawk
 - [bean-format](https://beancount.github.io/docs/running_beancount_and_generating_reports.html#bean-format) - Reformat Beancount files to right-align all the numbers at the same, minimal column.
 - [beautysh](https://github.com/lovesegfault/beautysh) - A Bash beautifier for the masses.
 - [bibtex-tidy](https://github.com/FlamingTempura/bibtex-tidy) - Cleaner and Formatter for BibTeX files.

--- a/doc/conform.txt
+++ b/doc/conform.txt
@@ -263,7 +263,7 @@ FORMATTERS                                                    *conform-formatter
             pyflakes.
 `autopep8` - A tool that automatically formats Python code to conform to the PEP
            8 style guide.
-`gawk` - Format awk programs with gawk
+`gawk` - Format awk programs with gawk.
 `bean-format` - Reformat Beancount files to right-align all the numbers at the
               same, minimal column.
 `beautysh` - A Bash beautifier for the masses.

--- a/doc/conform.txt
+++ b/doc/conform.txt
@@ -263,7 +263,7 @@ FORMATTERS                                                    *conform-formatter
             pyflakes.
 `autopep8` - A tool that automatically formats Python code to conform to the PEP
            8 style guide.
-`awk` - Format awk programs with awk
+`gawk` - Format awk programs with gawk
 `bean-format` - Reformat Beancount files to right-align all the numbers at the
               same, minimal column.
 `beautysh` - A Bash beautifier for the masses.

--- a/lua/conform/formatters/awk.lua
+++ b/lua/conform/formatters/awk.lua
@@ -3,6 +3,7 @@ return {
   meta = {
     url = "https://www.gnu.org/software/gawk/manual/gawk.html",
     description = "Format awk programs with gawk.",
+    deprecated = true,
   },
   command = "gawk",
   args = { "-f", "-", "-o-" },

--- a/lua/conform/formatters/awk.lua
+++ b/lua/conform/formatters/awk.lua
@@ -5,6 +5,6 @@ return {
     description = "Format awk programs with gawk.",
     deprecated = true,
   },
-  command = "gawk",
+  command = "awk",
   args = { "-f", "-", "-o-" },
 }

--- a/lua/conform/formatters/gawk.lua
+++ b/lua/conform/formatters/gawk.lua
@@ -2,8 +2,8 @@
 return {
   meta = {
     url = "https://www.gnu.org/software/gawk/manual/gawk.html",
-    description = "Format awk programs with awk",
+    description = "Format awk programs with gawk",
   },
-  command = "awk",
+  command = "gawk",
   args = { "-f", "-", "-o-" },
 }


### PR DESCRIPTION
I made a similar pull request in mfussenger/nvim-lint ([#684]) a while back.
Same as in that case, gawk is more or less the only awk implementation that
supports formatting of awk files, thus I find it make sense to have the
formatter named gawk instead. Could also prevent problems for people who use
Alpine as an example, which by default uses Busybox's awk implementation, but
still would like to have an awk formatter configured for when gawk is available.

[#684]: https://github.com/mfussenegger/nvim-lint/pull/684
