### PR TITLE
fix(runner): replace `$FILENAME` last, since it can contain `%` which would fail when `gsub` `$RANDOM`

### DIFF
--- a/lua/conform/runner.lua
+++ b/lua/conform/runner.lua
@@ -489,7 +489,7 @@ M.build_context = function(bufnr, config, range)
     end
     local basename = vim.fs.basename(filename)
     local tmpname =
-      template:gsub("$FILENAME", basename):gsub("$RANDOM", tostring(math.random(1000000, 9999999)))
+      template:gsub("$RANDOM", tostring(math.random(1000000, 9999999))):gsub("$FILENAME", basename)
     local parent = vim.fs.dirname(filename)
     filename = fs.join(parent, tmpname)
   end


### PR DESCRIPTION
If the `basename` contains `%` characters, that line fails.
This fixes that.

Fixes https://github.com/folke/snacks.nvim/issues/187