### PR TITLE
Fix buildifier formatting of BUILD file

### DIFF
--- a/lua/conform/formatters/buildifier.lua
+++ b/lua/conform/formatters/buildifier.lua
@@ -5,4 +5,5 @@ return {
     description = "buildifier is a tool for formatting bazel BUILD and .bzl files with a standard convention.",
   },
   command = "buildifier",
+  args = { "-path", "$FILENAME", "-" },
 }


### PR DESCRIPTION
When editing a file named BUILD, the command `buildifier` was executed, but the file in the editor was not reformatted properly.

If I'd run `buildifier [path-to-file]`, the file would be reformatted as expected, so the formatter works as expected in this case.

After experimenting a bit, I came up with the new command line I propose in this change. It still sends the code via stdin to `buildifier`, but now is aware of the path the file has in the project. This seems to have an influence on the behavior of `buildifier`.

See `buildifier --help`:

```
  -type string
        Input file type: build (for BUILD files), bzl (for .bzl files),
        workspace (for WORKSPACE files), default (for generic Starlark
        files) or auto (default, based on the filename) (default "auto")
```