### PR TITLE
fix: create ConformInfo regardless of setup

### DIFF
--- a/lua/conform/init.lua
+++ b/lua/conform/init.lua
@@ -222,10 +222,6 @@ M.setup = function(opts)
       end,
     })
   end
-
-  vim.api.nvim_create_user_command("ConformInfo", function()
-    require("conform.health").show_window()
-  end, { desc = "Show information about Conform formatters" })
 end
 
 ---@param obj any

--- a/plugin/conform.lua
+++ b/plugin/conform.lua
@@ -1,0 +1,3 @@
+vim.api.nvim_create_user_command("ConformInfo", function()
+  require("conform.health").show_window()
+end, { desc = "Show information about Conform formatters" })


### PR DESCRIPTION
There is little to no benefit to create `ConformInfo` only if the user calls the setup function since you can use this plugin without never calling it.