### PR TITLE
fix(format-queries): require nvim-treesitter before scaning rtp

### DIFF
--- a/lua/conform/formatters/format-queries.lua
+++ b/lua/conform/formatters/format-queries.lua
@@ -11,7 +11,7 @@ return {
   },
   condition = function()
     local ok = pcall(vim.treesitter.language.inspect, "query")
-    return ok and get_format_script() ~= nil
+    return ok and pcall(require, "nvim-treesitter") and get_format_script() ~= nil
   end,
   command = "nvim",
   args = function()


### PR DESCRIPTION
`scripts/format-queries.lua` live in https://github.com/nvim-treesitter/nvim-treesitter repository.
Those who lazy load this plugin should require it before searching the `rtp`.
