### PR TITLE
feat: add pre and post formatter hooks

### DIFF
--- a/lua/conform/runner.lua
+++ b/lua/conform/runner.lua
@@ -298,6 +298,10 @@ local last_run_errored = {}
 ---@param callback fun(err?: conform.Error, output?: string[])
 ---@return integer? job_id
 local function run_formatter(bufnr, formatter, config, ctx, input_lines, opts, callback)
+  vim.api.nvim_exec_autocmds("User", {
+    pattern = "ConformPreFormatter",
+    data = { formatter = formatter },
+  })
   log.info("Run %s on %s", formatter.name, vim.api.nvim_buf_get_name(bufnr))
   log.trace("Input lines: %s", input_lines)
   callback = util.wrap_callback(callback, function(err)
@@ -434,6 +438,13 @@ local function run_formatter(bufnr, formatter, config, ctx, input_lines, opts, c
           })
         end
       end
+      vim.api.nvim_exec_autocmds("User", {
+        pattern = "ConformPostFormatter",
+        data = {
+          formatter = formatter,
+          success = result.code == 0,
+        },
+      })
     end)
   )
   if not ok then

--- a/lua/conform/runner.lua
+++ b/lua/conform/runner.lua
@@ -304,7 +304,7 @@ local function run_formatter(bufnr, formatter, config, ctx, input_lines, opts, c
     },
   }
   vim.api.nvim_exec_autocmds("User", {
-    pattern = "ConformPreFormatter",
+    pattern = "ConformFormatPre",
     data = autocmd_data,
   })
   log.info("Run %s on %s", formatter.name, vim.api.nvim_buf_get_name(bufnr))
@@ -320,7 +320,7 @@ local function run_formatter(bufnr, formatter, config, ctx, input_lines, opts, c
     end
     autocmd_data["err"] = err
     vim.api.nvim_exec_autocmds("User", {
-      pattern = "ConformPostFormatter",
+      pattern = "ConformFormatPost",
       data = autocmd_data,
     })
   end)


### PR DESCRIPTION
This is a feature I've added to my local copy of `conform.nvim` which I wondered if you would be interested in adding! I would've created and issue instead but I thought I'd just do a PR instead as I had already made the changes locally.

## What?
Auto command triggers for `ConformPreFormatter` and `ConformPostFormatter` which fire before and after each formatter that is called. This allows hooking into the format process for each formatter.

## Why?
I've added this as the formatters I have to run for work can sometimes take a while and there doesn't seem to be any feedback as to which formatter is currently running. 

Adding these hooks enables me to have the following auto commands:
```lua
vim.api.nvim_create_autocmd("User", {
  pattern = 'ConformPreFormatter',
  callback = function(event)
    print('running ' .. event.data.formatter.name)
  end
})

vim.api.nvim_create_autocmd("User", {
  pattern = 'ConformPostFormatter',
  callback = function(event)
    print(string.format('finished running %s: ok=%s', event.data.formatter.name, event.data.ok))
  end
})
```

which results in the following:

https://github.com/user-attachments/assets/1f9206f5-2598-43d0-8c75-c8bc79c0eea8