### PR TITLE
feat: added js-beautify (w/ css- & html-beautify)

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ You can view this list in vim with `:help conform-formatters`
 - [grain_format](https://grain-lang.org/docs/tooling/grain_cli#grain-format) - Code formatter for the grain programming language.
 - [hcl](https://github.com/hashicorp/hcl) - A formatter for HCL files.
 - [hindent](https://github.com/mihaimaruseac/hindent) - Haskell pretty printer.
-- [html_beautify](https://github.com/beautifier/js-beautify) - This little beautifier will reformat and re-indent bookmarklets, ugly JavaScript, unpack scripts packed by Dean Edward’s popular packer, as well as partly deobfuscate scripts processed by the npm package javascript-obfuscator.
+- [html_beautify](https://github.com/beautifier/js-beautify) - Beautifier for html.
 - [htmlbeautifier](https://github.com/threedaymonk/htmlbeautifier) - A normaliser/beautifier for HTML that also understands embedded Ruby. Ideal for tidying up Rails templates.
 - [imba_fmt](https://imba.io/) - Code formatter for the Imba programming language.
 - [indent](https://www.gnu.org/software/indent/) - GNU Indent.

--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ You can view this list in vim with `:help conform-formatters`
 - [crlfmt](https://github.com/cockroachdb/crlfmt) - Formatter for CockroachDB's additions to the Go style guide.
 - [crystal](https://crystal-lang.org/) - Format Crystal code.
 - [csharpier](https://github.com/belav/csharpier) - The opinionated C# code formatter.
-- [css_beautify](https://github.com/beautifier/js-beautify) - This little beautifier will reformat and re-indent bookmarklets, ugly JavaScript, unpack scripts packed by Dean Edward’s popular packer, as well as partly deobfuscate scripts processed by the npm package javascript-obfuscator.
+- [css_beautify](https://github.com/beautifier/js-beautify) - Beautifier for css.
 - [cue_fmt](https://cuelang.org) - Format CUE files using `cue fmt` command.
 - [d2](https://github.com/terrastruct/d2) - D2 is a modern diagram scripting language that turns text to diagrams.
 - [darker](https://github.com/akaihola/darker) - Run black only on changed lines.

--- a/README.md
+++ b/README.md
@@ -270,6 +270,7 @@ You can view this list in vim with `:help conform-formatters`
 - [jq](https://github.com/stedolan/jq) - Command-line JSON processor.
 - [jsonnetfmt](https://github.com/google/go-jsonnet/tree/master/cmd/jsonnetfmt) - jsonnetfmt is a command line tool to format jsonnet files.
 - [just](https://github.com/casey/just) - Format Justfile.
+- [js-beautify](https://github.com/beautifier/js-beautify) - Beautifier for javascript.
 - [kcl](https://www.kcl-lang.io/docs/tools/cli/kcl/fmt) - The KCL Format tool modifies the files according to the KCL code style.
 - [kdlfmt](https://github.com/hougesen/kdlfmt) - A formatter for kdl documents.
 - [ktfmt](https://github.com/facebook/ktfmt) - Reformats Kotlin source code to comply with the common community standard conventions.

--- a/README.md
+++ b/README.md
@@ -214,6 +214,7 @@ You can view this list in vim with `:help conform-formatters`
 - [crlfmt](https://github.com/cockroachdb/crlfmt) - Formatter for CockroachDB's additions to the Go style guide.
 - [crystal](https://crystal-lang.org/) - Format Crystal code.
 - [csharpier](https://github.com/belav/csharpier) - The opinionated C# code formatter.
+- [css_beautify](https://github.com/beautifier/js-beautify) - This little beautifier will reformat and re-indent bookmarklets, ugly JavaScript, unpack scripts packed by Dean Edward’s popular packer, as well as partly deobfuscate scripts processed by the npm package javascript-obfuscator.
 - [cue_fmt](https://cuelang.org) - Format CUE files using `cue fmt` command.
 - [d2](https://github.com/terrastruct/d2) - D2 is a modern diagram scripting language that turns text to diagrams.
 - [darker](https://github.com/akaihola/darker) - Run black only on changed lines.
@@ -260,6 +261,7 @@ You can view this list in vim with `:help conform-formatters`
 - [grain_format](https://grain-lang.org/docs/tooling/grain_cli#grain-format) - Code formatter for the grain programming language.
 - [hcl](https://github.com/hashicorp/hcl) - A formatter for HCL files.
 - [hindent](https://github.com/mihaimaruseac/hindent) - Haskell pretty printer.
+- [html_beautify](https://github.com/beautifier/js-beautify) - This little beautifier will reformat and re-indent bookmarklets, ugly JavaScript, unpack scripts packed by Dean Edward’s popular packer, as well as partly deobfuscate scripts processed by the npm package javascript-obfuscator.
 - [htmlbeautifier](https://github.com/threedaymonk/htmlbeautifier) - A normaliser/beautifier for HTML that also understands embedded Ruby. Ideal for tidying up Rails templates.
 - [imba_fmt](https://imba.io/) - Code formatter for the Imba programming language.
 - [indent](https://www.gnu.org/software/indent/) - GNU Indent.
@@ -268,9 +270,9 @@ You can view this list in vim with `:help conform-formatters`
 - [isort](https://github.com/PyCQA/isort) - Python utility / library to sort imports alphabetically and automatically separate them into sections and by type.
 - [joker](https://github.com/candid82/joker) - Small Clojure interpreter, linter and formatter.
 - [jq](https://github.com/stedolan/jq) - Command-line JSON processor.
+- [js_beautify](https://github.com/beautifier/js-beautify) - This little beautifier will reformat and re-indent bookmarklets, ugly JavaScript, unpack scripts packed by Dean Edward’s popular packer, as well as partly deobfuscate scripts processed by the npm package javascript-obfuscator.
 - [jsonnetfmt](https://github.com/google/go-jsonnet/tree/master/cmd/jsonnetfmt) - jsonnetfmt is a command line tool to format jsonnet files.
 - [just](https://github.com/casey/just) - Format Justfile.
-- [js-beautify](https://github.com/beautifier/js-beautify) - Beautifier for javascript.
 - [kcl](https://www.kcl-lang.io/docs/tools/cli/kcl/fmt) - The KCL Format tool modifies the files according to the KCL code style.
 - [kdlfmt](https://github.com/hougesen/kdlfmt) - A formatter for kdl documents.
 - [ktfmt](https://github.com/facebook/ktfmt) - Reformats Kotlin source code to comply with the common community standard conventions.

--- a/README.md
+++ b/README.md
@@ -270,7 +270,7 @@ You can view this list in vim with `:help conform-formatters`
 - [isort](https://github.com/PyCQA/isort) - Python utility / library to sort imports alphabetically and automatically separate them into sections and by type.
 - [joker](https://github.com/candid82/joker) - Small Clojure interpreter, linter and formatter.
 - [jq](https://github.com/stedolan/jq) - Command-line JSON processor.
-- [js_beautify](https://github.com/beautifier/js-beautify) - This little beautifier will reformat and re-indent bookmarklets, ugly JavaScript, unpack scripts packed by Dean Edward’s popular packer, as well as partly deobfuscate scripts processed by the npm package javascript-obfuscator.
+- [js_beautify](https://github.com/beautifier/js-beautify) - Beautifier for javascript.
 - [jsonnetfmt](https://github.com/google/go-jsonnet/tree/master/cmd/jsonnetfmt) - jsonnetfmt is a command line tool to format jsonnet files.
 - [just](https://github.com/casey/just) - Format Justfile.
 - [kcl](https://www.kcl-lang.io/docs/tools/cli/kcl/fmt) - The KCL Format tool modifies the files according to the KCL code style.

--- a/doc/conform.txt
+++ b/doc/conform.txt
@@ -365,10 +365,7 @@ FORMATTERS                                                    *conform-formatter
 `grain_format` - Code formatter for the grain programming language.
 `hcl` - A formatter for HCL files.
 `hindent` - Haskell pretty printer.
-`html_beautify` - This little beautifier will reformat and re-indent
-                bookmarklets, ugly JavaScript, unpack scripts packed by Dean
-                Edward’s popular packer, as well as partly deobfuscate scripts
-                processed by the npm package javascript-obfuscator.
+`html_beautify` - Beautifier for html.
 `htmlbeautifier` - A normaliser/beautifier for HTML that also understands
                  embedded Ruby. Ideal for tidying up Rails templates.
 `imba_fmt` - Code formatter for the Imba programming language.

--- a/doc/conform.txt
+++ b/doc/conform.txt
@@ -298,10 +298,7 @@ FORMATTERS                                                    *conform-formatter
 `crlfmt` - Formatter for CockroachDB's additions to the Go style guide.
 `crystal` - Format Crystal code.
 `csharpier` - The opinionated C# code formatter.
-`css_beautify` - This little beautifier will reformat and re-indent
-               bookmarklets, ugly JavaScript, unpack scripts packed by Dean
-               Edward’s popular packer, as well as partly deobfuscate scripts
-               processed by the npm package javascript-obfuscator.
+`css_beautify` - Beautifier for css.
 `cue_fmt` - Format CUE files using `cue fmt` command.
 `d2` - D2 is a modern diagram scripting language that turns text to diagrams.
 `darker` - Run black only on changed lines.

--- a/doc/conform.txt
+++ b/doc/conform.txt
@@ -379,10 +379,7 @@ FORMATTERS                                                    *conform-formatter
         automatically separate them into sections and by type.
 `joker` - Small Clojure interpreter, linter and formatter.
 `jq` - Command-line JSON processor.
-`js_beautify` - This little beautifier will reformat and re-indent bookmarklets,
-              ugly JavaScript, unpack scripts packed by Dean Edward’s popular
-              packer, as well as partly deobfuscate scripts processed by the npm
-              package javascript-obfuscator.
+`js_beautify` - Beautifier for javascript.
 `jsonnetfmt` - jsonnetfmt is a command line tool to format jsonnet files.
 `just` - Format Justfile.
 `kcl` - The KCL Format tool modifies the files according to the KCL code style.

--- a/doc/conform.txt
+++ b/doc/conform.txt
@@ -298,6 +298,10 @@ FORMATTERS                                                    *conform-formatter
 `crlfmt` - Formatter for CockroachDB's additions to the Go style guide.
 `crystal` - Format Crystal code.
 `csharpier` - The opinionated C# code formatter.
+`css_beautify` - This little beautifier will reformat and re-indent
+               bookmarklets, ugly JavaScript, unpack scripts packed by Dean
+               Edward’s popular packer, as well as partly deobfuscate scripts
+               processed by the npm package javascript-obfuscator.
 `cue_fmt` - Format CUE files using `cue fmt` command.
 `d2` - D2 is a modern diagram scripting language that turns text to diagrams.
 `darker` - Run black only on changed lines.
@@ -361,6 +365,10 @@ FORMATTERS                                                    *conform-formatter
 `grain_format` - Code formatter for the grain programming language.
 `hcl` - A formatter for HCL files.
 `hindent` - Haskell pretty printer.
+`html_beautify` - This little beautifier will reformat and re-indent
+                bookmarklets, ugly JavaScript, unpack scripts packed by Dean
+                Edward’s popular packer, as well as partly deobfuscate scripts
+                processed by the npm package javascript-obfuscator.
 `htmlbeautifier` - A normaliser/beautifier for HTML that also understands
                  embedded Ruby. Ideal for tidying up Rails templates.
 `imba_fmt` - Code formatter for the Imba programming language.
@@ -371,6 +379,10 @@ FORMATTERS                                                    *conform-formatter
         automatically separate them into sections and by type.
 `joker` - Small Clojure interpreter, linter and formatter.
 `jq` - Command-line JSON processor.
+`js_beautify` - This little beautifier will reformat and re-indent bookmarklets,
+              ugly JavaScript, unpack scripts packed by Dean Edward’s popular
+              packer, as well as partly deobfuscate scripts processed by the npm
+              package javascript-obfuscator.
 `jsonnetfmt` - jsonnetfmt is a command line tool to format jsonnet files.
 `just` - Format Justfile.
 `kcl` - The KCL Format tool modifies the files according to the KCL code style.

--- a/lua/conform/formatters/css_beautify.lua
+++ b/lua/conform/formatters/css_beautify.lua
@@ -5,7 +5,7 @@ local util = require("conform.util")
 return {
   meta = {
     url = "https://github.com/beautifier/js-beautify",
-    description = [[This little beautifier will reformat and re-indent bookmarklets, ugly JavaScript, unpack scripts packed by Dean Edward’s popular packer, as well as partly deobfuscate scripts processed by the npm package javascript-obfuscator.]],
+    description = "Beautifier for css.",
   },
   command = util.from_node_modules(fs.is_windows and "css-beautify.cmd" or "css-beautify"),
   args = { "--file", "-" },

--- a/lua/conform/formatters/css_beautify.lua
+++ b/lua/conform/formatters/css_beautify.lua
@@ -1,0 +1,16 @@
+local fs = require("conform.fs")
+local util = require("conform.util")
+
+---@type conform.FileFormatterConfig
+return {
+  meta = {
+    url = "https://github.com/beautifier/js-beautify",
+    description = [[This little beautifier will reformat and re-indent bookmarklets, ugly JavaScript, unpack scripts packed by Dean Edward’s popular packer, as well as partly deobfuscate scripts processed by the npm package javascript-obfuscator.]],
+  },
+  command = util.from_node_modules(fs.is_windows and "css-beautify.cmd" or "css-beautify"),
+  args = { "--file", "-" },
+  cwd = util.root_file({
+    -- https://github.com/beautifier/js-beautify#loading-settings-from-environment-or-jsbeautifyrc-javascript-only
+    ".jsbeautifyrc",
+  }),
+}

--- a/lua/conform/formatters/html_beautify.lua
+++ b/lua/conform/formatters/html_beautify.lua
@@ -1,0 +1,16 @@
+local fs = require("conform.fs")
+local util = require("conform.util")
+
+---@type conform.FileFormatterConfig
+return {
+  meta = {
+    url = "https://github.com/beautifier/js-beautify",
+    description = [[This little beautifier will reformat and re-indent bookmarklets, ugly JavaScript, unpack scripts packed by Dean Edward’s popular packer, as well as partly deobfuscate scripts processed by the npm package javascript-obfuscator.]],
+  },
+  command = util.from_node_modules(fs.is_windows and "html-beautify.cmd" or "html-beautify"),
+  args = { "--file", "-" },
+  cwd = util.root_file({
+    -- https://github.com/beautifier/js-beautify#loading-settings-from-environment-or-jsbeautifyrc-javascript-only
+    ".jsbeautifyrc",
+  }),
+}

--- a/lua/conform/formatters/html_beautify.lua
+++ b/lua/conform/formatters/html_beautify.lua
@@ -5,7 +5,7 @@ local util = require("conform.util")
 return {
   meta = {
     url = "https://github.com/beautifier/js-beautify",
-    description = [[This little beautifier will reformat and re-indent bookmarklets, ugly JavaScript, unpack scripts packed by Dean Edward’s popular packer, as well as partly deobfuscate scripts processed by the npm package javascript-obfuscator.]],
+    description = "Beautifier for html.",
   },
   command = util.from_node_modules(fs.is_windows and "html-beautify.cmd" or "html-beautify"),
   args = { "--file", "-" },

--- a/lua/conform/formatters/js_beautify.lua
+++ b/lua/conform/formatters/js_beautify.lua
@@ -5,7 +5,7 @@ local util = require("conform.util")
 return {
   meta = {
     url = "https://github.com/beautifier/js-beautify",
-    description = [[This little beautifier will reformat and re-indent bookmarklets, ugly JavaScript, unpack scripts packed by Dean Edward’s popular packer, as well as partly deobfuscate scripts processed by the npm package javascript-obfuscator.]],
+    description = "Beautifier for javascript.",
   },
   command = util.from_node_modules(fs.is_windows and "js-beautify.cmd" or "js-beautify"),
   args = { "--file", "-" },

--- a/lua/conform/formatters/js_beautify.lua
+++ b/lua/conform/formatters/js_beautify.lua
@@ -1,0 +1,16 @@
+local fs = require("conform.fs")
+local util = require("conform.util")
+
+---@type conform.FileFormatterConfig
+return {
+  meta = {
+    url = "https://github.com/beautifier/js-beautify",
+    description = [[This little beautifier will reformat and re-indent bookmarklets, ugly JavaScript, unpack scripts packed by Dean Edward’s popular packer, as well as partly deobfuscate scripts processed by the npm package javascript-obfuscator.]],
+  },
+  command = util.from_node_modules(fs.is_windows and "js-beautify.cmd" or "js-beautify"),
+  args = { "--file", "-" },
+  cwd = util.root_file({
+    -- https://github.com/beautifier/js-beautify#loading-settings-from-environment-or-jsbeautifyrc-javascript-only
+    ".jsbeautifyrc",
+  }),
+}


### PR DESCRIPTION
Added [js-beautify](https://github.com/beautifier/js-beautify) to conform.nvim, using [stdin](https://github.com/beautifier/js-beautify#options)

I took inspiration from the prettier config; though I haven't actually tested the "fs.is_windows and js-beautify.cmd" part (I don't have a Windows to test on)

js-beautify comes with two extra bins: `html-beautify` and `css-beautify`; which is just a [an easy interface](https://github.com/beautifier/js-beautify?tab=readme-ov-file#css--html) to `js-beautify` (passing in `--html` and `--css` respectively)

What do you think is the best way to implement this? They all take the same basic arguments, as such the 3 different implementations I made currently are all copy/paste, except for the binary name

Let me know what you think :-)