### PR TITLE
feat: added sqruff

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,6 +340,7 @@ You can view this list in vim with `:help conform-formatters`
 - [sql_formatter](https://github.com/sql-formatter-org/sql-formatter) - A whitespace formatter for different query languages.
 - [sqlfluff](https://github.com/sqlfluff/sqlfluff) - A modular SQL linter and auto-formatter with support for multiple dialects and templated code.
 - [sqlfmt](https://docs.sqlfmt.com) - sqlfmt formats your dbt SQL files so you don't have to. It is similar in nature to Black, gofmt, and rustfmt (but for SQL)
+- [sqruff](https://github.com/quarylabs/sqruff) - sqruff is a SQL linter and formatter written in Rust.
 - [squeeze_blanks](https://www.gnu.org/software/coreutils/manual/html_node/cat-invocation.html#cat-invocation) - Squeeze repeated blank lines into a single blank line via `cat -s`.
 - [standard-clj](https://github.com/oakmac/standard-clojure-style-js) - A JavaScript library to format Clojure code according to Standard Clojure Style.
 - [standardjs](https://standardjs.com) - JavaScript Standard style guide, linter, and formatter.

--- a/lua/conform/formatters/sqruff.lua
+++ b/lua/conform/formatters/sqruff.lua
@@ -1,0 +1,16 @@
+local util = require("conform.util")
+
+---@type conform.FileFormatterConfig
+return {
+  meta = {
+    url = "https://github.com/quarylabs/sqruff",
+    description = "sqruff is a SQL linter and formatter written in Rust.",
+  },
+  command = "sqruff",
+  args = { "fix", "-" },
+  cwd = util.root_file({
+    -- https://github.com/quarylabs/sqruff/tree/main#configuration
+    ".sqruff",
+  }),
+  require_cwd = true,
+}


### PR DESCRIPTION
[sqruff](https://github.com/quarylabs/sqruff) is a promising new tool, that combines the speed of `ruff` with usefulness of `sqlfluff`

This implementation is heavily inspired by the [sqlfluff](https://github.com/stevearc/conform.nvim/blob/master/lua/conform/formatters/sqlfluff.lua) implementation (they are pretty much identical)

While sqruff works without a `.sqruff` file, it hardly makes sense to do so. So I've kept the enforcement of cwd