### PR TITLE
feat: added pyproject-fmt

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,6 +320,7 @@ You can view this list in vim with `:help conform-formatters`
 - [puppet-lint](https://github.com/puppetlabs/puppet-lint) - Check that your Puppet manifests conform to the style guide.
 - [purs-tidy](https://github.com/natefaubion/purescript-tidy) - A syntax tidy-upper for PureScript.
 - [pyink](https://github.com/google/pyink) - A Python formatter, forked from Black with a few different formatting behaviors.
+- [pyproject-fmt](https://github.com/tox-dev/toml-fmt/tree/main/pyproject-fmt) - Apply a consistent format to your pyproject.toml file with comment support.
 - [python-ly](https://github.com/frescobaldi/python-ly) - A Python package and commandline tool to manipulate LilyPond files.
 - [reorder-python-imports](https://github.com/asottile/reorder-python-imports) - Rewrites source to reorder python imports
 - [rescript-format](https://rescript-lang.org/) - The built-in ReScript formatter.

--- a/lua/conform/formatters/pyproject-fmt.lua
+++ b/lua/conform/formatters/pyproject-fmt.lua
@@ -1,0 +1,16 @@
+local util = require("conform.util")
+---@type conform.FileFormatterConfig
+return {
+  meta = {
+    url = "https://github.com/tox-dev/toml-fmt/tree/main/pyproject-fmt",
+    description = "Apply a consistent format to your pyproject.toml file with comment support.",
+  },
+  command = "pyproject-fmt",
+  args = {
+    "-",
+  },
+  cwd = util.root_file({
+    "pyproject.toml",
+  }),
+  exit_codes = { 0, 1 }, -- 1 error code used when formatting is successful and if there are errors
+}


### PR DESCRIPTION
This adds support for [pyproject-fmt](https://github.com/tox-dev/toml-fmt/tree/main/pyproject-fmt) which is used to format `pyproject.toml` files in a Python project