### PR TITLE
feat: add hurlfmt (hurl files)

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,7 @@ You can view this list in vim with `:help conform-formatters`
 - [hindent](https://github.com/mihaimaruseac/hindent) - Haskell pretty printer.
 - [html_beautify](https://github.com/beautifier/js-beautify) - Beautifier for html.
 - [htmlbeautifier](https://github.com/threedaymonk/htmlbeautifier) - A normaliser/beautifier for HTML that also understands embedded Ruby. Ideal for tidying up Rails templates.
+- [hurlfmt](https://hurl.dev/) - Formats hurl files.
 - [imba_fmt](https://imba.io/) - Code formatter for the Imba programming language.
 - [indent](https://www.gnu.org/software/indent/) - GNU Indent.
 - [injected](doc/advanced_topics.md#injected-language-formatting-code-blocks) - Format treesitter injected languages.

--- a/lua/conform/formatters/hurlfmt.lua
+++ b/lua/conform/formatters/hurlfmt.lua
@@ -1,0 +1,8 @@
+---@type conform.FileFormatterConfig
+return {
+  meta = {
+    url = "https://hurl.dev/",
+    description = "Formats hurl files.",
+  },
+  command = "hurlfmt",
+}


### PR DESCRIPTION
Adds the `hurlfmt` formatter for hurl files.

See: 
 - https://hurl.dev/
 - https://github.com/Orange-OpenSource/hurl/blob/master/docs/manual/hurlfmt.md