### PR TITLE
use styler natively for R instead of calling it via r.nvim::format

### DIFF
--- a/lua/conform/formatters/styler.lua
+++ b/lua/conform/formatters/styler.lua
@@ -6,6 +6,9 @@ return {
     description = "R formatter and linter.",
   },
   command = util.find_executable({ "usr/bin/" }, "R"),
-  args = { "-s", "-e", "r.nvim::format()", "--args", "$FILENAME" },
+  -- Any args to style_file must be passed after `commandArgs(TRUE)`
+  -- Include "--no-init-file" before "e" to ignore .Rprofile, for example
+  -- to avoid long renv startup time
+  args = { "-s", "-e", "styler::style_file(commandArgs(TRUE))", "--args", "$FILENAME" },
   stdin = false,
 }


### PR DESCRIPTION
Currrently the styler command in conform relies on the user using R.nvim and having the associated r package installed. However, under the hood, r.nvim just calls styler directly. I have updated the default styler configuration to do the same. I have also added some comments describing usage. This is related to #275.