### PR TITLE
feat: add codeql native formatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,7 @@ You can view this list in vim with `:help conform-formatters`
 - [cljstyle](https://github.com/greglook/cljstyle) - Formatter for Clojure code.
 - [cmake_format](https://github.com/cheshirekow/cmake_format) - Parse cmake listfiles and format them nicely.
 - [codespell](https://github.com/codespell-project/codespell) - Check code for common misspellings.
+- [codeql](https://docs.github.com/en/code-security/codeql-cli/codeql-cli-manual/query-format) - Format queries and libraries with CodeQL.
 - [commitmsgfmt](https://gitlab.com/mkjeldsen/commitmsgfmt) - Formats commit messages better than fmt(1) and Vim.
 - [crlfmt](https://github.com/cockroachdb/crlfmt) - Formatter for CockroachDB's additions to the Go style guide.
 - [crystal](https://crystal-lang.org/) - Format Crystal code.

--- a/doc/conform.txt
+++ b/doc/conform.txt
@@ -294,6 +294,7 @@ FORMATTERS                                                    *conform-formatter
 `cljstyle` - Formatter for Clojure code.
 `cmake_format` - Parse cmake listfiles and format them nicely.
 `codespell` - Check code for common misspellings.
+`codeql` - Format queries and libraries with CodeQL.
 `commitmsgfmt` - Formats commit messages better than fmt(1) and Vim.
 `crlfmt` - Formatter for CockroachDB's additions to the Go style guide.
 `crystal` - Format Crystal code.

--- a/lua/conform/formatters/codeql.lua
+++ b/lua/conform/formatters/codeql.lua
@@ -1,0 +1,9 @@
+---@type conform.FileFormatterConfig
+return {
+  meta = {
+    url = "https://docs.github.com/en/code-security/codeql-cli/codeql-cli-manual/query-format",
+    description = "Format queries and libraries with CodeQL.",
+  },
+  command = "codeql",
+  args = { "query", "format", "-" },
+}


### PR DESCRIPTION
Added support for the codeql query formatter. Documentation can be found [here](https://docs.github.com/en/code-security/codeql-cli/codeql-cli-manual/query-format)