### PR TITLE
fix: fix uncaught undojoin after undo error

### DIFF
--- a/lua/conform/lsp_format.lua
+++ b/lua/conform/lsp_format.lua
@@ -32,7 +32,7 @@ local function apply_text_edits(text_edits, bufnr, offset_encoding, dry_run, und
     return #text_edits > 0
   else
     if undojoin then
-      vim.cmd.undojoin()
+      pcall(vim.cmd.undojoin)
     end
     vim.lsp.util.apply_text_edits(text_edits, bufnr, offset_encoding)
     return #text_edits > 0


### PR DESCRIPTION
Catch the "undojoin after undo" error the same way as the other call to `vim.cmd.undojoin`.