### PR TITLE
fix(latexindent): regression in `f2063898e9`

### DIFF
--- a/lua/conform/formatters/latexindent.lua
+++ b/lua/conform/formatters/latexindent.lua
@@ -5,9 +5,9 @@ return {
     description = "A perl script for formatting LaTeX files that is generally included in major TeX distributions.",
   },
   command = "latexindent",
-  args = {},
+  args = { "-" },
   range_args = function(_, ctx)
-    return { "--lines", ctx.range.start[1] .. "-" .. ctx.range["end"][1] }
+    return { "--lines", ctx.range.start[1] .. "-" .. ctx.range["end"][1], "-" }
   end,
   stdin = true,
 }


### PR DESCRIPTION
When ran with the `-l` flag and no other filename (as is the case when passing the file through STDIN), latexindent interprets the argument to `-l` as the file to be formatted

Eg. `latexindent -l=foo.yaml < bar.tex` overwrites the current buffer with `foo.yaml` rather than the formatted `bar.tex`

This commit just appends the argument `-` so that STDIN is always used

See: `f2063898e943893b20aeb30a324d5364ebaddff6` (#654)

Note: Issue can be replicated by passing the following option to `setup`:

```
formatters = {
	latexindent = {
		prepend_args = { "-l=foo.yaml" },
	},
},
```

The formatter will overwrite the buffer with the attempted formatting of `foo.yaml` if it exists, and just error out if it doesn't