### PR TITLE
Enable cabal-fmt to process expand pragmas

### DIFF
--- a/lua/conform/formatters/cabal_fmt.lua
+++ b/lua/conform/formatters/cabal_fmt.lua
@@ -4,5 +4,6 @@ return {
     description = "Format cabal files with cabal-fmt",
   },
   command = "cabal-fmt",
-  stdin = true,
+  args = { "--inplace", "$FILENAME" },
+  stdin = false,
 }

--- a/lua/conform/formatters/cabal_fmt.lua
+++ b/lua/conform/formatters/cabal_fmt.lua
@@ -1,7 +1,7 @@
 return {
   meta = {
     url = "https://hackage.haskell.org/package/cabal-fmt",
-    description = "Format cabal files with cabal-fmt",
+    description = "Format cabal files with cabal-fmt.",
   },
   command = "cabal-fmt",
   args = { "--inplace", "$FILENAME" },


### PR DESCRIPTION
A comment like

```cabal
-- cabal-fmt: expand src/
```

cannot be processed without a file path, which means the filename needs
to be passed as input.
