### PR TITLE
fix(prettypst): stdin and stdout args

### DIFF
--- a/lua/conform/formatters/prettypst.lua
+++ b/lua/conform/formatters/prettypst.lua
@@ -5,5 +5,6 @@ return {
     description = "Formatter for Typst.",
   },
   command = "prettypst",
+  args = { "--use-std-in", "--use-std-out" },
   stdin = true,
 }


### PR DESCRIPTION
This tells prettypst to use stdin and stdout for the formatting. Before it errored out and did not format the buffer.