### PR TITLE
Added support of toolchains for rustfmt

### DIFF
--- a/doc/formatter_options.md
+++ b/doc/formatter_options.md
@@ -97,6 +97,7 @@ options = {
 options = {
   -- The default edition of Rust to use when no Cargo.toml file is found
   default_edition = "2021",
+  default_toolchain = "stable"
 }
 ```
 

--- a/lua/conform/formatters/rustfmt.lua
+++ b/lua/conform/formatters/rustfmt.lua
@@ -10,9 +10,11 @@ return {
   options = {
     -- The default edition of Rust to use when no Cargo.toml file is found
     default_edition = "2021",
+    default_toolchain = "stable",
   },
   args = function(self, ctx)
-    local args = { "--emit=stdout" }
+    local toolchain = "+" .. self.options.default_toolchain
+    local args = { toolchain, "--emit=stdout" }
     local edition = util.parse_rust_edition(ctx.dirname) or self.options.default_edition
     table.insert(args, "--edition=" .. edition)
 


### PR DESCRIPTION
I added the ability to pick a toolchain for rustfmt. This will allow nightly formatting rules while using a non-nightly toolchain.