### PR TITLE
Fix syntax_tree for ignored files

### DIFF
--- a/lua/conform/formatters/syntax_tree.lua
+++ b/lua/conform/formatters/syntax_tree.lua
@@ -5,7 +5,7 @@ return {
     description = "Syntax Tree is a suite of tools built on top of the internal CRuby parser.",
   },
   command = "stree",
-  stdin = false,
-  args = { "write", "$FILENAME" },
+  stdin = true,
+  args = { "format", "$RELATIVE_FILEPATH" },
   cwd = require("conform.util").root_file({ ".streerc" }),
 }


### PR DESCRIPTION
First, thank you for this project.

I wanted to suggest this change for the `syntax_tree` formatter based on a project I'm working on.

Running the command with the actual relative path (not a temp path) allows it to honor any `--ignore-files` configuration in the .streerc file. It is true that we're actually ignoring the stdin, so that might make this change a non-starter.

But it does work. Given an `.streerc` config like this:

```
--ignore-files=bar.rb
```

The `bar.rb` file will not be formatted.