### PR TITLE
fix(sqruff): update args, stdin and require_cwd

### DIFF
--- a/lua/conform/formatters/sqruff.lua
+++ b/lua/conform/formatters/sqruff.lua
@@ -7,10 +7,11 @@ return {
     description = "sqruff is a SQL linter and formatter written in Rust.",
   },
   command = "sqruff",
-  args = { "fix", "-" },
+  stdin = false,
+  args = { "fix", "--force", "$FILENAME" },
   cwd = util.root_file({
     -- https://github.com/quarylabs/sqruff/tree/main#configuration
     ".sqruff",
   }),
-  require_cwd = true,
+  require_cwd = false,
 }


### PR DESCRIPTION
The arg "--force" must be used for auto formatting, otherwise it logs error in ConformInfo when trying to format.

Reading from stdin seams not working,
thus stdin is set to false and "$FILENAME" is used instead.

sqruff doesn't require cwd (the ".sqruff" file).
Without ".sqruff", it uses the default config.