### PR TITLE
fix(csharpier)!: use csharpier format command

### DIFF
--- a/lua/conform/formatters/csharpier.lua
+++ b/lua/conform/formatters/csharpier.lua
@@ -1,10 +1,44 @@
+local COMMAND = "dotnet"
+local TOOL = "csharpier"
+local cache = nil -- For performance
+
+--- Verify if csharpier is installed locally.
+---@return boolean
+local function is_local()
+  if cache == nil then
+    local obj = vim.system({ COMMAND, TOOL, "--version" }):wait()
+    cache = obj.code == 0
+  end
+  return cache
+end
+
+--- Get command favoring locally installed csharpier.
+---@return string
+local function get_command()
+  if is_local() then
+    return COMMAND
+  end
+  return TOOL
+end
+
+--- Get args favoring locally installed csharpier.
+---@return string[]
+local function get_args()
+  local args = {}
+  if is_local() then
+    table.insert(args, TOOL)
+  end
+  table.insert(args, "format")
+  return args
+end
+
 ---@type conform.FileFormatterConfig
 return {
   meta = {
     url = "https://github.com/belav/csharpier",
     description = "The opinionated C# code formatter.",
   },
-  command = "dotnet",
-  args = { "csharpier", "format" },
+  command = get_command,
+  args = get_args,
   stdin = true,
 }

--- a/lua/conform/formatters/csharpier.lua
+++ b/lua/conform/formatters/csharpier.lua
@@ -5,6 +5,6 @@ return {
     description = "The opinionated C# code formatter.",
   },
   command = "dotnet",
-  args = { "csharpier", "--write-stdout" },
+  args = { "csharpier", "format" },
   stdin = true,
 }


### PR DESCRIPTION
Since the `1.0.0` release of csharpier, the CLI has changed and the `format` 
command is required. Moreover, the `--write-stdout` option is implicit when the 
content comes from stdin, and therefore can be removed.

BREAKING-CHANGE: The new arguments for the CLI require csharpier
`>= 1.0.0`.