### PR TITLE
fix(csharpier): support new cli for csharpier 1.0.x

### DIFF
--- a/lua/conform/formatters/csharpier.lua
+++ b/lua/conform/formatters/csharpier.lua
@@ -5,6 +5,6 @@ return {
     description = "The opinionated C# code formatter.",
   },
   command = "dotnet",
-  args = { "csharpier", "--write-stdout" },
+  args = { "csharpier", "format", "$FILENAME", "--write-stdout" },
   stdin = true,
 }


### PR DESCRIPTION
with csharpier going to version 1 it has changed the api.  This will be a breaking change if people aren't running on csharpier 1.0.x.