### PR TITLE
fix(csharpier): Updated to make compatible with csharpier v1.x.x api

### DIFF
--- a/lua/conform/formatters/csharpier.lua
+++ b/lua/conform/formatters/csharpier.lua
@@ -1,10 +1,69 @@
----@type conform.FileFormatterConfig
-return {
-  meta = {
-    url = "https://github.com/belav/csharpier",
-    description = "The opinionated C# code formatter.",
-  },
-  command = "dotnet",
-  args = { "csharpier", "--write-stdout" },
-  stdin = true,
-}
+local log = require("conform.log")
+
+--- Validate that the `dotnet` runtime and the CSharpier global tool are present.
+--- Logging errors if something is missing.
+local function validate_dotnet()
+  local has_dotnet = vim.fn.executable("dotnet")
+
+  if not has_dotnet then
+    log.error("dotnet is missing from path")
+    return
+  end
+
+  vim.fn.system("dotnet csharpier --version")
+
+  if vim.v.shell_error ~= 0 then
+    log.error(
+      "`dotnet csharpier --version` exited with a non 0 exit code, is it installed globally"
+    )
+  end
+end
+
+--- Get the command to execute for csharpier, when installed with mason it will be added to the nvim path.
+--- If not installed with mason it is assumed to be installed as a dotnet tool.
+---
+--- Where the mason version will be prioritized over the dotnet version.
+--- @return string
+local function get_command()
+  local in_path = vim.fn.executable("csharpier")
+
+  validate_dotnet()
+  if not in_path then
+    validate_dotnet()
+  end
+
+  return in_path and "csharpier" or "dotnet csharpier"
+end
+
+--- Return the major version (1.x.x) as an integer of csharpier, as for version 1.0.0 the api has changed. So this
+--- is used to preserve backwards compatibility.
+--- @return integer
+local function get_major_version(command)
+  local version_out = vim.fn.system(command .. " --version")
+
+  return tonumber((version_out or ""):match("^(%d+)")) or 0
+end
+
+local function build_args()
+  local command = get_command()
+
+  local major_version = get_major_version(command)
+
+  local v1_api = major_version >= 1
+
+  local args = v1_api and { "format", "$FILENAME" } or { "--write-stdout" }
+
+  ---@type conform.FileFormatterConfig
+  return {
+    meta = {
+      url = "https://github.com/belav/csharpier",
+      description = "The opinionated C# code formatter.",
+    },
+    command = command,
+    args = args,
+    stdin = not v1_api,
+    require_cwd = false,
+  }
+end
+
+return build_args()

--- a/lua/conform/formatters/csharpier.lua
+++ b/lua/conform/formatters/csharpier.lua
@@ -27,7 +27,6 @@ end
 local function get_command()
   local in_path = vim.fn.executable("csharpier")
 
-  validate_dotnet()
   if not in_path then
     validate_dotnet()
   end
@@ -51,7 +50,7 @@ local function build_args()
 
   local v1_api = major_version >= 1
 
-  local args = v1_api and { "format", "$FILENAME" } or { "--write-stdout" }
+  local args = v1_api and { "format", "$FILENAME", "--write-stdout" } or { "--write-stdout" }
 
   ---@type conform.FileFormatterConfig
   return {
@@ -61,7 +60,7 @@ local function build_args()
     },
     command = command,
     args = args,
-    stdin = not v1_api,
+    stdin = true,
     require_cwd = false,
   }
 end


### PR DESCRIPTION
Address bug #699, by making the following changes;

1. Check for and use the `csharpier` installed by mason, fallback to `dotnet csharpier`
2. If the version is >= 1 use the new api command

I tested this with mason installing the package at version 1.0.1 and 0.30.0 (I tried 0.30.6 but there where some errors). I did not try it with it installed as a dotnet tool, but the executable should be the same its on the path that changes.
