### PR TITLE
formatters: add dioxus (`dx fmt`)

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,7 @@ You can view this list in vim with `:help conform-formatters`
 - [dcm_format](https://dcm.dev/docs/cli/formatting/format/) - Formats .dart files.
 - [deno_fmt](https://deno.land/manual/tools/formatter) - Use [Deno](https://deno.land/) to format TypeScript, JavaScript/JSON and markdown.
 - [dfmt](https://github.com/dlang-community/dfmt) - Formatter for D source code.
+- [dioxus](https://github.com/dioxuslabs/dioxus) - Format `rsx!` snippets in Rust files.
 - [djlint](https://github.com/Riverside-Healthcare/djLint) - ✨ HTML Template Linter and Formatter. Django - Jinja - Nunjucks - Handlebars - GoLang.
 - [docformatter](https://pypi.org/project/docformatter/) - docformatter automatically formats docstrings to follow a subset of the PEP 257 conventions.
 - [docstrfmt](https://github.com/LilSpazJoekp/docstrfmt) - reStructuredText formatter.

--- a/doc/conform.txt
+++ b/doc/conform.txt
@@ -333,6 +333,7 @@ FORMATTERS                                                    *conform-formatter
 `docstrfmt` - reStructuredText formatter.
 `doctoc` - Generates table of contents for markdown files inside local git
          repository.
+`dioxus` - Format `rsx!` snippets in Rust files.
 `dprint` - Pluggable and configurable code formatting platform written in Rust.
 `easy-coding-standard` - ecs - Use Coding Standard with 0-knowledge of PHP-CS-
                        Fixer and PHP_CodeSniffer.

--- a/lua/conform/formatters/dioxus.lua
+++ b/lua/conform/formatters/dioxus.lua
@@ -1,0 +1,13 @@
+local util = require("conform.util")
+
+---@type conform.FileFormatterConfig
+return {
+  meta = {
+    url = "https://github.com/dioxuslabs/dioxus",
+    description = "Format `rsx!` snippets in Rust files.",
+  },
+  stdin = false,
+  command = "dx",
+  args = { "fmt", "--file", "$FILENAME" },
+  cwd = util.root_file({ "Dioxus.toml" }),
+}


### PR DESCRIPTION
i prefer to use it with `require_cwd = true` and the config snippet below, but i think they're too much of a personal preference to include in the pr

```lua
formatters_by_ft.rust = function()
  if vim.fn.executable("dx") == 1 then
    return { "rustfmt", "dioxus" }
  end
  return { "rustfmt" }
end
```

