### PR TITLE
Add .cljstyle as the root file for cljstyle formatter

### DIFF
--- a/lua/conform/formatters/cljstyle.lua
+++ b/lua/conform/formatters/cljstyle.lua
@@ -6,4 +6,5 @@ return {
   },
   command = "cljstyle",
   args = { "pipe" },
+  cwd = require("conform.util").root_file({ ".cljstyle" }),
 }


### PR DESCRIPTION
`cljstyle` uses a hierarchy of `.cljstyle` configuration files in the source tree to change formatting behavior, so if it is run in the wrong directory the formatting may be incorrect.

This sets the cwd to one that contains a `.cljstyle` file.

https://github.com/greglook/cljstyle?tab=readme-ov-file#configuration