### PR TITLE
Fix inserting to the end of a range

### DIFF
--- a/tests/runner_spec.lua
+++ b/tests/runner_spec.lua
@@ -385,6 +385,18 @@ print("a")
         )
         assert.are.same({ "a", "d", "c" }, vim.api.nvim_buf_get_lines(0, 0, -1, false))
       end)
+
+      it("applies edits that are inserting at the end of the range", function()
+        run_formatter(
+          "a\nb\nc",
+          "a\nb\nc\nd",
+          { range = {
+            start = { 2, 0 },
+            ["end"] = { 3, 0 },
+          } }
+        )
+        assert.are.same({ "a", "b", "c", "d" }, vim.api.nvim_buf_get_lines(0, 0, -1, false))
+      end)
     end)
 
     it("can run the format command in the shell", function()


### PR DESCRIPTION
When you are formatting with a range, and the formatter tries to insert at the end of the range, `conform.nvim` will fail to insert because it will consider the insert to be happening "outside of the range". But if it's an insert operation that starts immediately after the range, it should be considered still part of the range, since that's basically "appending" to the range, making it longer.

This happens a lot with Markdown formatters, for example. Markdown formatters will reorganize reference links alphabetically, meaning they can change the order of links and remove a link from the start of the link section and insert it at the end of the link section, basically "appending" the link at the end.

First, I add a failing test. Then, I add the code that fixes the test.