### PR TITLE
Fix dart format not picking up config file

### DIFF
--- a/lua/conform/formatters/dart_format.lua
+++ b/lua/conform/formatters/dart_format.lua
@@ -5,5 +5,7 @@ return {
     description = "Replace the whitespace in your program with formatting that follows Dart guidelines.",
   },
   command = "dart",
-  args = { "format" },
+  args = { "format", "$FILENAME" },
+  -- Using stdin does not currently work properly, because the formatter will not pick up the analysis_options.yaml file
+  stdin = false,
 }


### PR DESCRIPTION
Regarding #712 

The dart formatter does not pick up analysis_options.yaml when used in stdin mode