### PR TITLE
Add official swift formatter

### DIFF
--- a/lua/conform/formatters/swift.lua
+++ b/lua/conform/formatters/swift.lua
@@ -1,0 +1,10 @@
+---@type conform.FileFormatterConfig
+return {
+  meta = {
+    url = "https://github.com/swiftlang/swift-format",
+    description = "Official Swift formatter. Requires Swift 6.0 or later.",
+  },
+  command = "swift",
+  args = { "format", "$FILENAME", "--in-place" },
+  stdin = false,
+}

--- a/lua/conform/formatters/swift_format.lua
+++ b/lua/conform/formatters/swift_format.lua
@@ -1,8 +1,8 @@
 ---@type conform.FileFormatterConfig
 return {
   meta = {
-    url = "https://github.com/apple/swift-format",
-    description = "Swift formatter from apple. Requires building from source with `swift build`.",
+    url = "https://github.com/swiftlang/swift-format",
+    description = "Official Swift formatter. For Swift 6.0 or later prefer setting the `swift` formatter instead.",
   },
   command = "swift-format",
   args = { "$FILENAME", "--in-place" },


### PR DESCRIPTION
The swift-format from apple has been moved to https://github.com/swiftlang/swift-format now and, since version 6.0, it is included in the `swift` CLI.

I have added the CLI one as a new formatter and kept the old one, as it is still required for earlier versions.

I have also removed the instructions saying that build from source was required, as it is now available via Homebrew.