### PR TITLE
Update csharpier after breaking change in 1.x release

### DIFF
--- a/lua/conform/formatters/csharpier.lua
+++ b/lua/conform/formatters/csharpier.lua
@@ -5,6 +5,6 @@ return {
     description = "The opinionated C# code formatter.",
   },
   command = "dotnet",
-  args = { "csharpier", "--write-stdout" },
+  args = { "csharpier", "format", "--write-stdout" },
   stdin = true,
 }


### PR DESCRIPTION
As of release 1, csharpier slightly reworked their CLI syntax (see https://github.com/belav/csharpier/releases/tag/1.0.0).

We now have to type:
```bash
dotnet csharpier format <file>
```
instead of
```bash
dotnet csharpier <file>
```

Thus, we have to adjust the command in conform.