### PR TITLE
feat: add tailwindcss-language-formatter

### DIFF
--- a/lua/conform/formatters/tailwindcss-language-server.lua
+++ b/lua/conform/formatters/tailwindcss-language-server.lua
@@ -1,0 +1,9 @@
+---@type conform.FileFormatterConfig
+return {
+  meta = {
+    url = "https://www.npmjs.com/package/@tailwindcss/language-server",
+    description = "Language Server Protocol implementation for Tailwind CSS, used by Tailwind CSS IntelliSense for VS Code.",
+  },
+  command = "tailwindcss-language-server",
+  args = { "--stdio", "node-ipc", "--socket=<port>" },
+}


### PR DESCRIPTION
i have no idea what to add inside `args` . You can just check the lsp on `meta.url`. Also, are there any docs for contributors about adding formatters?