### PR TITLE
(feat): add commands to toggle conform's format on save

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,9 @@ require("conform").setup({
 })
 ```
 
+If you use this, conform will also set up two commands so you can turn on and off the format-on-save functionality.
+`:ConformEnable` and `:ConformDisable`
+
 See [conform.format()](#formatopts-callback) for more details about the parameters.
 
 Conform also provides a formatexpr, same as the LSP client:

--- a/lua/conform/init.lua
+++ b/lua/conform/init.lua
@@ -124,6 +124,12 @@ M.setup = function(opts)
       opts.format_on_save = {}
     end
     local autoformat_autocmd_ID = create_autoformat_autocmd(aug, opts.format_on_save)
+    vim.api.nvim_create_user_command("ConformEnable", function()
+      autoformat_autocmd_ID = create_autoformat_autocmd(aug, opts.format_on_save)
+    end, {})
+    vim.api.nvim_create_user_command("ConformDisable", function()
+      vim.api.nvim_del_autocmd(autoformat_autocmd_ID)
+    end, {})
   end
 
   if opts.format_after_save then

--- a/lua/conform/init.lua
+++ b/lua/conform/init.lua
@@ -120,16 +120,6 @@ M.setup = function(opts)
         end
       end,
     })
-    vim.api.nvim_create_autocmd("VimLeavePre", {
-      desc = "conform.nvim hack to work around Neovim bug",
-      pattern = "*",
-      group = aug,
-      callback = function()
-        -- HACK: Work around https://github.com/neovim/neovim/issues/21856
-        -- causing exit code 134 on :wq
-        vim.cmd.sleep({ args = { "1m" } })
-      end,
-    })
   end
 
   if opts.format_after_save then


### PR DESCRIPTION
i use autoformat on autosave in my personal neovim config with custom autocommands (i do some regex stuff after post format), but sometimes stuff breaks, and then i need to manually disable the autosave function from my config, but i already fixed it in my personal config by making some use commands to turn it off and on. So i thought why not just implement it on the main repo too


i added two handy little commands, `:ConformEnable` and `:ConformDisable` which only gets set if you use the format-on-save functionality.