### PR TITLE
feat: add support for ghdl

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,7 @@ You can view this list in vim with `:help conform-formatters`
 - [gci](https://github.com/daixiang0/gci) - GCI, a tool that controls Go package import order and makes it always deterministic.
 - [gdformat](https://github.com/Scony/godot-gdscript-toolkit) - A formatter for Godot's gdscript.
 - [gersemi](https://github.com/BlankSpruce/gersemi) - A formatter to make your CMake code the real treasure.
+- [ghdl](https://ghdl.github.io/ghdl/) - Open-source analyzer, compiler, simulator and synthesizer for VHDL.
 - [ghokin](https://github.com/antham/ghokin) - Parallelized formatter with no external dependencies for gherkin.
 - [gleam](https://github.com/gleam-lang/gleam) - ⭐️ A friendly language for building type-safe, scalable systems!
 - [gluon_fmt](https://github.com/gluon-lang/gluon) - Code formatting for the gluon programming language.

--- a/doc/conform.txt
+++ b/doc/conform.txt
@@ -364,6 +364,7 @@ FORMATTERS                                                    *conform-formatter
       deterministic.
 `gdformat` - A formatter for Godot's gdscript.
 `gersemi` - A formatter to make your CMake code the real treasure.
+`ghdl` - Open-source analyzer, compiler, simulator and synthesizer for VHDL.
 `ghokin` - Parallelized formatter with no external dependencies for gherkin.
 `gleam` - ⭐️ A friendly language for building type-safe, scalable systems!
 `gluon_fmt` - Code formatting for the gluon programming language.

--- a/lua/conform/formatters/ghdl.lua
+++ b/lua/conform/formatters/ghdl.lua
@@ -1,0 +1,9 @@
+---@type conform.FileFormatterConfig
+return {
+  meta = {
+    url = "https://ghdl.github.io/ghdl/",
+    description = "Open-source analyzer, compiler, simulator and synthesizer for VHDL.",
+  },
+  command = "ghdl",
+  args = { "fmt", "--std=08", "$FILENAME" },
+}


### PR DESCRIPTION
This PR adds GHDL <https://github.com/ghdl/ghdl>, using its `fmt` command. It requires a filename arg, but it only prints to stdout, hence no `stdin = false` yet `$FILENAME` in `args`.

I guess the `--std=08` flag can be questioned, but that is what I used for the GHDL linter in nvim-lint <https://github.com/mfussenegger/nvim-lint/blob/master/lua/lint/linters/ghdl.lua>. I'm no expert but I believe VHDL 2008 to be mostly backward compatible, and formatting on most of my files fails without the flag. Also that's 17 years... But say if you want to omit.