### PR TITLE
feat(formatters): add pymarkdownlnt

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,6 +338,7 @@ You can view this list in vim with `:help conform-formatters`
 - [purs-tidy](https://github.com/natefaubion/purescript-tidy) - A syntax tidy-upper for PureScript.
 - [pycln](https://github.com/hadialqattan/pycln) - A Python formatter for finding and removing unused import statements.
 - [pyink](https://github.com/google/pyink) - A Python formatter, forked from Black with a few different formatting behaviors.
+- [pymarkdownlnt](https://github.com/jackdewinter/pymarkdown) - PyMarkdown is primarily a Markdown linter.
 - [pyproject-fmt](https://github.com/tox-dev/toml-fmt/tree/main/pyproject-fmt) - Apply a consistent format to your pyproject.toml file with comment support.
 - [python-ly](https://github.com/frescobaldi/python-ly) - A Python package and commandline tool to manipulate LilyPond files.
 - [pyupgrade](https://github.com/asottile/pyupgrade) - A tool to automatically upgrade syntax for newer versions of Python.

--- a/lua/conform/formatters/pymarkdownlnt.lua
+++ b/lua/conform/formatters/pymarkdownlnt.lua
@@ -1,0 +1,10 @@
+---@type conform.FileFormatterConfig
+return {
+  meta = {
+    url = "https://github.com/jackdewinter/pymarkdown",
+    description = "PyMarkdown is primarily a Markdown linter",
+  },
+  command = "pymarkdownlnt",
+  args = { "--return-code-scheme", "minimal", "fix", "$FILENAME" },
+  stdin = false,
+}

--- a/lua/conform/formatters/pymarkdownlnt.lua
+++ b/lua/conform/formatters/pymarkdownlnt.lua
@@ -2,7 +2,7 @@
 return {
   meta = {
     url = "https://github.com/jackdewinter/pymarkdown",
-    description = "PyMarkdown is primarily a Markdown linter",
+    description = "A markdown linter and formatter.",
   },
   command = "pymarkdownlnt",
   args = { "--return-code-scheme", "minimal", "fix", "$FILENAME" },


### PR DESCRIPTION
[pymarkdownlnt] is the python equivalent to the obiquitous markdownlint. For python projects, it makes more sense to use the former in order to avoid pulling Node.js and its dependencies. Add it to the official formatters.

[pymarkdownlnt]: https://github.com/jackdewinter/pymarkdown