### PR TITLE
Update csharpier args to latest version

### DIFF
--- a/lua/conform/formatters/csharpier.lua
+++ b/lua/conform/formatters/csharpier.lua
@@ -5,6 +5,6 @@ return {
     description = "The opinionated C# code formatter.",
   },
   command = "dotnet",
-  args = { "csharpier", "--write-stdout" },
+  args = { "csharpier", "format", "--write-stdout" },
   stdin = true,
 }


### PR DESCRIPTION
Csharpier introduced a command `format` that is missing from current config which is causing the formatting to fail.