### PR TITLE
feat(uncrustify): use project cfg if it exists

### DIFF
--- a/lua/conform/formatters/uncrustify.lua
+++ b/lua/conform/formatters/uncrustify.lua
@@ -5,15 +5,14 @@ return {
     description = "A source code beautifier for C, C++, C#, ObjectiveC, D, Java, Pawn and Vala.",
   },
   command = "uncrustify",
-  args = function(self, ctx)
-    local config_name = "uncrustify.cfg"
+  args = function(_, ctx)
     local args = { "-q", "-l", vim.bo[ctx.buf].filetype:upper() }
 
     -- Find uncrustify.cfg in the project if it exists
-    local cfg_path = require("conform.util").root_file(config_name)(self, ctx)
+    local cfg_path = vim.fs.find("uncrustify.cfg", { upward = true, path = ctx.dirname })[1]
     if cfg_path then
       table.insert(args, "-c")
-      table.insert(args, cfg_path .. require("conform.fs").sep .. config_name)
+      table.insert(args, cfg_path)
     end
     return args
   end,


### PR DESCRIPTION
According to the docs, uncrustify doesn't load a project local config automatically. Instead, it loads config as follows:

```
       -c CFG Use the config file CFG, or defaults if CFG is set to '-'.
              If not specified, uncrustify will use $UNCRUSTIFY_CONFIG or $HOME/.uncrustify.cfg.
```

I'm doing some work with the neovim source and it has a project local uncrustify.cfg so I updated the formatter to use a project local config if it exists.