### PR TITLE
Update Terragrunt format command

### DIFF
--- a/lua/conform/formatters/terragrunt_hclfmt.lua
+++ b/lua/conform/formatters/terragrunt_hclfmt.lua
@@ -5,7 +5,7 @@ return {
     description = "Format hcl files into a canonical format.",
   },
   command = "terragrunt",
-  args = { "hclfmt", "--terragrunt-hclfmt-file", "$FILENAME" },
+  args = { "hcl", "fmt", "--file", "$FILENAME" },
   stdin = false,
   condition = function(self, ctx)
     return vim.fs.basename(ctx.filename) ~= "terragrunt.hcl"


### PR DESCRIPTION
This is updating the way `terragrunt_hclfmt` performs formatting as recent updates to Terragrunt did deprecate the `hclfmt` command. The new way to perform the formatting is to use the new `hcl fmt` command.

The documentation can be found here: https://terragrunt.gruntwork.io/docs/reference/cli/commands/hcl/fmt/