### PR TITLE
fix(ghokin): Formatter "ghokin" you must provide a filename as argument

### DIFF
--- a/lua/conform/formatters/ghokin.lua
+++ b/lua/conform/formatters/ghokin.lua
@@ -6,5 +6,5 @@ return {
   },
 
   command = "ghokin",
-  args = { "fmt", "stdout" },
+  args = { "fmt", "stdout", "$FILENAME" },
 }


### PR DESCRIPTION
Fixes #769 

Adds `"$FILENAME"` argument to arg list so `ghokin` can format `cucumber` files