### PR TITLE
Added missing --stdin-filepath flag to Taplo formatter

### DIFF
--- a/lua/conform/formatters/taplo.lua
+++ b/lua/conform/formatters/taplo.lua
@@ -5,5 +5,5 @@ return {
     description = "A TOML toolkit written in Rust.",
   },
   command = "taplo",
-  args = { "format", "-" },
+  args = { "format", "--stdin-filepath", "$FILENAME", "-" },
 }


### PR DESCRIPTION
This PR adds the missing `--stdin-filepath` flag to the Taplo formatter.

Taplo formatter configuration files (`.taplo.toml`, `taplo.toml`) may contain rules that are specific to file patterns. If Taplo does not receive the `--stdin-filepath` flag, it will not apply these rules.