### PR TITLE
fix(treefmt): require config file

### DIFF
--- a/lua/conform/formatters/treefmt.lua
+++ b/lua/conform/formatters/treefmt.lua
@@ -6,4 +6,6 @@ return {
   },
   command = "treefmt",
   args = { "--stdin", "$FILENAME" },
+  require_cwd = true,
+  cwd = require("conform.util").root_file({ "treefmt.toml", ".treefmt.toml" }),
 }


### PR DESCRIPTION
Running `treefmt` when no config file exists just results in an error, so checking for the presence of a config file by default makes sense.

This will allow `treefmt` to be included as a formatter that should be run on all file types, without throwing errors for projects that have no treefmt config file.