### PR TITLE
fix(d2): format with temp file instead of stdin

### DIFF
--- a/lua/conform/formatters/d2.lua
+++ b/lua/conform/formatters/d2.lua
@@ -5,5 +5,9 @@ return {
     description = "D2 is a modern diagram scripting language that turns text to diagrams.",
   },
   command = "d2",
-  args = { "fmt", "-" },
+  stdin = false,
+  args = {
+    "fmt",
+    "$FILENAME",
+  },
 }


### PR DESCRIPTION
Currently d2 formatter use stdin format. It works fine with a d2 file. But with the injected formatter, it will delete the d2 content in the code block if the code block has no diff after being formatted. This PR make d2 format by filename instead of stdin.

D2 cli manual: https://d2lang.com/tour/man/

https://github.com/user-attachments/assets/4d800025-67b2-41a9-9bd5-66d3660b59ab

