### PR TITLE
feat(taplo): respect lsp options

### DIFF
--- a/lua/conform/formatters/taplo.lua
+++ b/lua/conform/formatters/taplo.lua
@@ -5,5 +5,18 @@ return {
     description = "A TOML toolkit written in Rust.",
   },
   command = "taplo",
-  args = { "format", "--stdin-filepath", "$FILENAME", "-" },
+  args = function()
+    ---@type lsp.LSPObject?
+    local taplo_config = vim.tbl_get(vim.lsp.config, "taplo", "settings", "formatter")
+
+    local ret = { "format" }
+    if taplo_config ~= nil then
+      for k, v in pairs(taplo_config) do
+        vim.list_extend(ret, { "-o", ("%s=%s"):format(k, v) })
+      end
+    end
+    vim.list_extend(ret, { "--stdin-filepath", "$FILENAME", "-" })
+
+    return ret
+  end,
 }


### PR DESCRIPTION
This PR makes the `taplo` formatter aware of the config options that can be set for it[^1] via the `taplo.settings.formatter` table.

[^1]: https://taplo.tamasfe.dev/cli/usage/formatting.html

- If there is no `vim.lsp.config.taplo` table present,
(For example if `neovim/nvim-lspconfig` is not installed)
or it doesn't contain a `settings.formatter` table the formatter will gracefully fall back to the current behavior.
- If the table does exist it will be converted into `-o key=value` arguments for `taplo`'s command line arguments.