### PR TITLE
feat: allow tmpfile to be created in a configurable directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -609,6 +609,7 @@ require("conform").setup({
       -- When cwd is not found, don't run the formatter (default false)
       require_cwd = true,
       -- When stdin=false, use this template to generate the temporary file that gets formatted
+      -- This can be an absolute path to control where the file is created.
       tmpfile_format = ".conform.$RANDOM.$FILENAME",
       -- When returns false, the formatter will not be used
       condition = function(self, ctx)

--- a/lua/conform/runner.lua
+++ b/lua/conform/runner.lua
@@ -370,6 +370,7 @@ local function run_formatter(bufnr, formatter, config, ctx, input_lines, opts, c
 
   if not config.stdin then
     log.debug("Creating temp file %s", ctx.filename)
+    vim.fn.mkdir(vim.fs.dirname(ctx.filename), "p")
     local fd = assert(uv.fs_open(ctx.filename, "w", 448)) -- 0700
     uv.fs_write(fd, buffer_text)
     uv.fs_close(fd)
@@ -508,8 +509,12 @@ M.build_context = function(bufnr, config, range)
     local basename = vim.fs.basename(filename)
     local tmpname =
       template:gsub("$RANDOM", tostring(math.random(1000000, 9999999))):gsub("$FILENAME", basename)
-    local parent = vim.fs.dirname(filename)
-    filename = fs.join(parent, tmpname)
+    if fs.is_absolute(tmpname) then
+      filename = tmpname
+    else
+      local parent = vim.fs.dirname(filename)
+      filename = fs.join(parent, tmpname)
+    end
   end
   return {
     buf = bufnr,

--- a/tests/runner_spec.lua
+++ b/tests/runner_spec.lua
@@ -108,6 +108,48 @@ describe("runner", function()
       assert.equal(dirname, ctx.dirname)
       assert.truthy(ctx.filename:match(dirname .. "/.conform.%d+.README.md$"))
     end)
+
+    it(
+      "sets temp file with absolute path when stdin = false and tmpfile_format is absolute",
+      function()
+        vim.cmd.edit({ args = { "README.md" } })
+        local bufnr = vim.api.nvim_get_current_buf()
+        conform.formatters.test = {
+          meta = { url = "", description = "" },
+          command = "echo",
+          stdin = false,
+          tmpfile_format = "/tmp/.conform.$RANDOM.$FILENAME",
+        }
+        local config = assert(conform.get_formatter_config("test"))
+        local ctx = runner.build_context(0, config)
+        local bufname = vim.api.nvim_buf_get_name(bufnr)
+        local dirname = vim.fs.dirname(bufname)
+        assert.equal(bufnr, ctx.buf)
+        assert.equal(dirname, ctx.dirname)
+        assert.truthy(ctx.filename:match("/tmp/.conform.%d+.README.md$"))
+      end
+    )
+
+    it(
+      "sets temp file with relative path when stdin = false and tmpfile_format is relative",
+      function()
+        vim.cmd.edit({ args = { "README.md" } })
+        local bufnr = vim.api.nvim_get_current_buf()
+        conform.formatters.test = {
+          meta = { url = "", description = "" },
+          command = "echo",
+          stdin = false,
+          tmpfile_format = "../.conform.$RANDOM.$FILENAME",
+        }
+        local config = assert(conform.get_formatter_config("test"))
+        local ctx = runner.build_context(0, config)
+        local bufname = vim.api.nvim_buf_get_name(bufnr)
+        local dirname = vim.fs.dirname(bufname)
+        assert.equal(bufnr, ctx.buf)
+        assert.equal(dirname, ctx.dirname)
+        assert.truthy(ctx.filename:match(dirname .. "/../.conform.%d+.README.md$"))
+      end
+    )
   end)
 
   describe("build_cmd", function()


### PR DESCRIPTION
This enables users to redirect temporary files to an external directory, such as /tmp, thus preventing conflicts with file watchers.

I have successfully tested the changes on my system. 

Please note that lots of the tests fail on my NixOS system, but I suspect this is due to the way NixOS works, so I haven't modified any of them. The two new tests pass, though.

fixes #694