### PR TITLE
fix(jq): use shiftwidth for indent

### DIFF
--- a/lua/conform/formatters/jq.lua
+++ b/lua/conform/formatters/jq.lua
@@ -5,4 +5,7 @@ return {
     description = "Command-line JSON processor.",
   },
   command = "jq",
+  args = function(_, ctx)
+    return { "--indent", ctx.shiftwidth }
+  end,
 }


### PR DESCRIPTION
The `jq` formatter doesn't currently doesn't take shiftwidth into account when formatting. This fixes that.