### PR TITLE
fix: treefmt

### DIFF
--- a/lua/conform/formatters/treefmt.lua
+++ b/lua/conform/formatters/treefmt.lua
@@ -6,6 +6,4 @@ return {
   },
   command = "treefmt",
   args = { "--stdin", "$FILENAME" },
-  require_cwd = true,
-  cwd = require("conform.util").root_file({ "treefmt.toml", ".treefmt.toml" }),
 }


### PR DESCRIPTION
As mentioned in my issue, while the check for treefmt.toml makes sense, it fails when the toml file is not there, leading to undesired behavior(as is the case in nix, using either treefmt-nix or nixpkgs.treefmt.withConfig). Marking as draft so that me and @zivarah can discuss over what we should do