### PR TITLE
fix(bake): use command 'mbake' for bake formatter

### DIFF
--- a/lua/conform/formatters/bake.lua
+++ b/lua/conform/formatters/bake.lua
@@ -4,7 +4,7 @@ return {
     url = "https://github.com/EbodShojaei/bake",
     description = "A Makefile formatter and linter.",
   },
-  command = "bake",
+  command = "mbake",
   args = { "format", "$FILENAME" },
   stdin = false,
 }


### PR DESCRIPTION
It seems the command `bake` is not working for the [bake](https://github.com/EbodShojaei/bake) formatter.

Therefore, I have changed the command from `bake` to `mbake` as [Usage@bake](https://github.com/EbodShojaei/bake#usage) shows.

I have installed bake via Mason, and there is no `bake` command, but only `mbake`.

@stvhuang Can you confirm that this fix is not breaking anything on your side as you added support for bake recently?