### PR TITLE
fix(mbake): correct mbake command and use stdin

### DIFF
--- a/lua/conform/formatters/bake.lua
+++ b/lua/conform/formatters/bake.lua
@@ -5,6 +5,5 @@ return {
     description = "A Makefile formatter and linter.",
   },
   command = "mbake",
-  args = { "format", "$FILENAME" },
-  stdin = false,
+  args = { "format", "--stdin" },
 }

--- a/lua/conform/formatters/mbake.lua
+++ b/lua/conform/formatters/mbake.lua
@@ -1,9 +1,0 @@
----@type conform.FileFormatterConfig
-return {
-  meta = {
-    url = "https://github.com/EbodShojaei/bake",
-    description = "A Makefile formatter and linter.",
-  },
-  command = "mbake",
-  args = { "format", "--stdin" },
-}


### PR DESCRIPTION
I noticed that the existing bake formatter was not working correctly after installing it with mason.nvim, and after some investigation, I found two main issues and fixed them in a new file mbake.lua.

I chose to create a new mbake.lua file and set its command = "mbake" instead of modifying the existing bake.lua because thats the name it has in pypi, mason, and its the current default (and i think only) name of the executable: https://github.com/EbodShojaei/bake/commit/f4b1c9f2424e3175b49771e05d2ea224c70f9db1 https://github.com/EbodShojaei/bake/commit/e60dec1bac98d1f8deda551252296bc0eeed0071
Having a formatter named mbake will be more intuitive i think.

Also, the previous approach (stdin = false and passing $FILENAME as an argument) caused the formatter to fail: mbake would correctly format the temporary file created by conform.nvim, but since it formats the file in-place, it doesn't return any output to stdout, which was interpreted as a failure and the (correctly formatted) temporary file was deleted, leaving the original buffer untouched.
This fix uses the --stdin flag, which was specifically added to mbake for editor integrations like this one. https://github.com/EbodShojaei/bake/commit/0cd0cbd8a11aaff7e6c9acf69341e8079b81b2b7

Finally, I'd like to mention that this is my first pull request to an open-source project. I'm incredibly excited to contribute, but I'm also aware that I might not have followed all the project's conventions perfectly.
I am completely open to any feedback, suggestions, or requested changes. Please let me know if there's anything I can do to improve this PR or future contributions!