### PR TITLE
fix(swiftformat): fix line range formatting

### DIFF
--- a/lua/conform/formatters/swiftformat.lua
+++ b/lua/conform/formatters/swiftformat.lua
@@ -8,12 +8,14 @@ return {
   stdin = true,
   args = { "--stdinpath", "$FILENAME" },
   range_args = function(self, ctx)
-    local startOffset = tonumber(ctx.range.start[1]) - 1
-    local endOffset = tonumber(ctx.range["end"][1]) - 1
+    local startOffset = ctx.range.start[1]
+    local endOffset = ctx.range["end"][1]
 
     return {
       "--linerange",
       startOffset .. "," .. endOffset,
+      "--stdinpath",
+      "$FILENAME",
     }
   end,
   cwd = require("conform.util").root_file({ ".swiftformat", "Package.swift", "buildServer.json" }),


### PR DESCRIPTION
SwiftFormat:
- expects 1-based line ranges
- needs the path of the file to find the configuration file
- conform.Range.start is an integer[] so tonumber was unnecessary