### PR TITLE
fix(jq): limit indetion to [-1,7]

### DIFF
--- a/lua/conform/formatters/jq.lua
+++ b/lua/conform/formatters/jq.lua
@@ -6,6 +6,6 @@ return {
   },
   command = "jq",
   args = function(_, ctx)
-    return { "--indent", ctx.shiftwidth }
+    return { "--indent", math.max(-1, math.min(7, ctx.shiftwidth)) }
   end,
 }


### PR DESCRIPTION
According to the documentation jq only accepts indention between -1 and
7.

Regression of 235dd79.