### PR TITLE
feat(health): set conform-info filetype in health windows

### DIFF
--- a/lua/conform/health.lua
+++ b/lua/conform/health.lua
@@ -205,6 +205,8 @@ M.show_window = function()
       hl_group = group,
     })
   end
+
+  vim.bo[bufnr].filetype = "conform-info"
 end
 
 return M


### PR DESCRIPTION
Problem: No filetype available for the user to set options in health windows

Solution: Set "conform-info" filetype in the show_window function