### PR TITLE
feat: add mh_style

### DIFF
--- a/lua/conform/formatters/mh_style.lua
+++ b/lua/conform/formatters/mh_style.lua
@@ -2,7 +2,7 @@
 return {
   meta = {
     url = "https://github.com/florianschanda/miss_hit",
-    description = "A simple coding style checker and code formatter for MATLAB or Octave code",
+    description = "A simple coding style checker and code formatter for MATLAB or Octave code.",
   },
   command = "mh_style",
   args = { "--fix", "$FILENAME" },


### PR DESCRIPTION
This PR adds configuration for the `matlab` formatter `mh_style` from the [miss_hit](https://github.com/florianschanda/miss_hit) tools.