### PR TITLE
fix(fprettify): fix config detection

### DIFF
--- a/lua/conform/formatters/fprettify.lua
+++ b/lua/conform/formatters/fprettify.lua
@@ -8,7 +8,7 @@ return {
   args = {
     -- --silent is recommended for editor integrations https://github.com/fortran-lang/fprettify?tab=readme-ov-file#editor-integration
     "--silent",
-    "-",
+    "$FILENAME",
   },
-  stdin = true,
+  stdin = false,
 }


### PR DESCRIPTION
When formatting from `stdin`, `fprettify` seems to ignore the configuration file `.fprettify.rc`.