### PR TITLE
feat: add Oxlint autofix

### DIFF
--- a/lua/conform/formatters/oxlint.lua
+++ b/lua/conform/formatters/oxlint.lua
@@ -4,9 +4,9 @@ local util = require("conform.util")
 return {
   meta = {
     url = "https://github.com/oxc-project/oxc",
-    description = "Oxlint (/oh-eks-lint/) is designed to catch erroneous or useless code without requiring any configurations by default.",
+    description = "An oxidized replacement for ESLint that fixes lint errors.",
   },
-  command = util.from_node_modules("oxfmt"),
+  command = util.from_node_modules("oxlint"),
   args = { "--fix", "$FILENAME" },
   stdin = false,
 }


### PR DESCRIPTION
I'm not sure is this PR is acceptable, it runs the Oxlint linter with the --fix argument that applies automatic fixes : https://oxc.rs/docs/guide/usage/linter/automatic-fixes.html

I had to add it to my config to replicate the auto-fix from the eslint LS.
The config is also be customized to include other kind of fixes :
`args = { "--fix-suggestions"}`

According to the documentation :
```
--fix                   # Safe fixes only
--fix-suggestions       # Safe suggestions only
--fix --fix-suggestions # Safe fixes and suggestions
```

But as it is not _really_ a formatter maybe it is out of scope?