### PR TITLE
Inform csharpier about the filepath of the formatted file

### DIFF
--- a/lua/conform/formatters/csharpier.lua
+++ b/lua/conform/formatters/csharpier.lua
@@ -30,7 +30,7 @@ return {
   end,
   args = function()
     if is_local() then
-      return { "csharpier", "format" }
+      return { "csharpier", "format", "--stdin-path", "$FILENAME" }
     else
       return { "format" }
     end


### PR DESCRIPTION
This fixes an issue discovered recently when working in a project where the .editorconfig and the dotnet project was in a subfolder to the "project root" (the location I was opening nvim from)

It lets csharpier know about the location of the file its currently formatting, and that seems to be enough to have cshapier respect the editorconfig settings, like it would if you would run the tool standalone where it modifies the files in place eg; `dotnet csharpier format .` 

The setting is documented here: 
https://csharpier.com/docs/CLI#commands

repo with a demo repo of what case this solves:
https://github.com/lukashermansson/csharpier-discrepency-demo

