### PR TITLE
fix: ensure integer is passed to vim.wait

### DIFF
--- a/lua/conform/runner.lua
+++ b/lua/conform/runner.lua
@@ -696,7 +696,7 @@ M.format_lines_sync = function(bufnr, formatters, timeout_ms, range, input_lines
     )
     all_support_range_formatting = all_support_range_formatting and truthy(config.range_args)
 
-    local wait_result, wait_reason = vim.wait(remaining, function()
+    local wait_result, wait_reason = vim.wait(math.floor(remaining), function()
       return done
     end, 5)
 


### PR DESCRIPTION
Neovim nightly introduced stricter integer checking for `vim.wait()` in https://github.com/neovim/neovim/pull/36885 which is causing an error `Lua callback: ...ocal/share/nvim/lazy/conform.nvim/lua/conform/runner.lua:699: timeout has no integer representation` on `conform.format`. This change uses `math.floor` to truncate the `remaining` timeout in order to coerce it to an integer.