### PR TITLE
feat: add ability to cancel silencing of repeated errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -598,6 +598,8 @@ require("conform").setup({
   log_level = vim.log.levels.ERROR,
   -- Conform will notify you when a formatter errors
   notify_on_error = true,
+  -- Conform will not repeat an error for a formatter if it errors successively
+  debounce_errors = true,
   -- Conform will notify you when no formatters are available for the buffer
   notify_no_formatters = true,
   -- Custom formatters and overrides for built-in formatters
@@ -698,6 +700,7 @@ require("conform").formatters.my_formatter = {
 | >format_after_save    | `nil\|conform.FormatOpts\|fun(bufnr: integer): nil\|conform.FormatOpts`                                          | , nil|fun(err: nil|string, did_edit: nil|boolean) If this is set, Conform will run the formatter asynchronously after save. It will pass the table to conform.format(). This can also be a function that returns the table (and an optional callback that is run after formatting). |
 | >log_level            | `nil\|integer`                                                                                                   | Set the log level (e.g. `vim.log.levels.DEBUG`). Use `:ConformInfo` to see the location of the log file.                                                                                                                                                                            |
 | >notify_on_error      | `nil\|boolean`                                                                                                   | Conform will notify you when a formatter errors (default true).                                                                                                                                                                                                                     |
+| >debounce_errors      | `nil\|boolean`                                                                                                   | Conform will not repeat an error for a formatter if it errors successively (default true).                                                                                                                                                                                                                     |
 | >notify_no_formatters | `nil\|boolean`                                                                                                   | Conform will notify you when no formatters are available for the buffer (default true).                                                                                                                                                                                             |
 | >formatters           | `nil\|table<string, conform.FormatterConfigOverride\|fun(bufnr: integer): nil\|conform.FormatterConfigOverride>` | Custom formatters and overrides for built-in formatters.                                                                                                                                                                                                                            |
 

--- a/doc/conform.txt
+++ b/doc/conform.txt
@@ -56,6 +56,8 @@ OPTIONS                                                          *conform-option
       log_level = vim.log.levels.ERROR,
       -- Conform will notify you when a formatter errors
       notify_on_error = true,
+      -- Conform will not repeat an error for a formatter if it errors successively
+      debounce_errors = true,
       -- Conform will notify you when no formatters are available for the buffer
       notify_no_formatters = true,
       -- Custom formatters and overrides for built-in formatters
@@ -162,6 +164,8 @@ setup({opts})                                                      *conform.setu
                              the location of the log file.
           {notify_on_error}  `nil|boolean` Conform will notify you when a
                              formatter errors (default true).
+          {debounce_errors}  `nil|boolean` Conform will silence errors when
+                             successively sent from the same formatter (default true).
           {notify_no_formatters} `nil|boolean` Conform will notify you when no
                              formatters are available for the buffer (default
                              true).

--- a/lua/conform/init.lua
+++ b/lua/conform/init.lua
@@ -7,6 +7,7 @@ M.formatters_by_ft = {}
 M.formatters = {}
 
 M.notify_on_error = true
+M.debounce_errors = true
 M.notify_no_formatters = true
 
 ---@type conform.DefaultFormatOpts
@@ -81,6 +82,9 @@ M.setup = function(opts)
   end
   if opts.notify_on_error ~= nil then
     M.notify_on_error = opts.notify_on_error
+  end
+  if opts.debounce_errors ~= nil then
+    M.debounce_errors = opts.debounce_errors
   end
   if opts.notify_no_formatters ~= nil then
     M.notify_no_formatters = opts.notify_no_formatters
@@ -479,7 +483,9 @@ M.format = function(opts, callback)
       -- Execution errors have special handling. Maybe should reconsider this.
       local notify_msg = err.message
       if errors.is_execution_error(err.code) then
-        should_notify = should_notify and M.notify_on_error and not err.debounce_message
+        should_notify = should_notify
+          and M.notify_on_error
+          and (not err.debounce_message or not M.debounce_errors)
         notify_msg = "Formatter failed. See :ConformInfo for details"
       end
       if should_notify then

--- a/lua/conform/types.lua
+++ b/lua/conform/types.lua
@@ -114,5 +114,6 @@
 ---@field format_after_save? conform.FormatOpts|fun(bufnr: integer): nil|conform.FormatOpts, nil|fun(err: nil|string, did_edit: nil|boolean) If this is set, Conform will run the formatter asynchronously after save. It will pass the table to conform.format(). This can also be a function that returns the table (and an optional callback that is run after formatting).
 ---@field log_level? integer Set the log level (e.g. `vim.log.levels.DEBUG`). Use `:ConformInfo` to see the location of the log file.
 ---@field notify_on_error? boolean Conform will notify you when a formatter errors (default true).
+---@field debounce_errors? boolean Conform will not repeat an error for a formatter if it errors successively (default true).
 ---@field notify_no_formatters? boolean Conform will notify you when no formatters are available for the buffer (default true).
 ---@field formatters? table<string, conform.FormatterConfigOverride|fun(bufnr: integer): nil|conform.FormatterConfigOverride> Custom formatters and overrides for built-in formatters.

--- a/scripts/options_doc.lua
+++ b/scripts/options_doc.lua
@@ -43,6 +43,8 @@ require("conform").setup({
   log_level = vim.log.levels.ERROR,
   -- Conform will notify you when a formatter errors
   notify_on_error = true,
+  -- Conform will not repeat an error for a formatter if it errors successively
+  debounce_errors = true,
   -- Conform will notify you when no formatters are available for the buffer
   notify_no_formatters = true,
   -- Custom formatters and overrides for built-in formatters


### PR DESCRIPTION
If my formatters are failing, personally I would like to keep seeing error messages as I debug. This allows to cancel the debouncing that is activated by default to see repeated errors.