### PR TITLE
feat: use stdin with oxfmt

### DIFF
--- a/lua/conform/formatters/oxfmt.lua
+++ b/lua/conform/formatters/oxfmt.lua
@@ -13,7 +13,7 @@ return {
     description = "A Prettier-compatible code formatter.",
   },
   command = util.from_node_modules("oxfmt"),
-  args = { "$FILENAME" },
-  stdin = false,
+  args = { "--stdin-filepath", "$FILENAME" },
+  stdin = true,
   cwd = require("conform.util").root_file(config_file_names),
 }


### PR DESCRIPTION
Just a coincidence, shortly after I submitted the PR to integrate Oxfmt with conform.nvim, they released version 0.18, which adds support for stdin. Apologies for any extra review work this may have caused.


https://github.com/oxc-project/oxc/pull/16868
https://github.com/oxc-project/oxc/releases/tag/apps_v1.33.0 
https://oxc.rs/docs/guide/usage/formatter/cli.html#mode-options