### PR TITLE
feat: add palantir-java-format

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,6 +330,7 @@ You can view this list in vim with `:help conform-formatters`
 - [oxfmt](https://github.com/oxc-project/oxc) - A Prettier-compatible code formatter.
 - [oxlint](https://github.com/oxc-project/oxc) - An oxidized replacement for ESLint that fixes lint errors.
 - [packer_fmt](https://developer.hashicorp.com/packer/docs/commands/fmt) - The packer fmt Packer command is used to format HCL2 configuration files to a canonical format and style.
+- [palantir-java-format](https://github.com/palantir/palantir-java-format) - A modern, lambda-friendly, 120 character Java formatter.
 - [pangu](https://github.com/vinta/pangu.py) - Insert whitespace between CJK and half-width characters.
 - [perlimports](https://github.com/perl-ide/App-perlimports) - Make implicit Perl imports explicit.
 - [perltidy](https://github.com/perltidy/perltidy) - Perl::Tidy, a source code formatter for Perl.

--- a/lua/conform/formatters/palantir-java-format.lua
+++ b/lua/conform/formatters/palantir-java-format.lua
@@ -1,0 +1,9 @@
+---@type conform.FileFormatterConfig
+return {
+  meta = {
+    url = "https://github.com/palantir/palantir-java-format",
+    description = "A modern, lambda-friendly, 120 character Java formatter.",
+  },
+  command = "palantir-java-format",
+  args = { "--palantir", "-" },
+}


### PR DESCRIPTION
You can compile `palantir-java-format` into a native binary and add it to your $PATH, as this comment describes: https://github.com/palantir/palantir-java-format/issues/1116#issuecomment-3246124770