### PR TITLE
fix: executable not being checked properly

### DIFF
--- a/lua/conform/util.lua
+++ b/lua/conform/util.lua
@@ -18,12 +18,14 @@ M.find_executable = function(paths, default)
     for _, path in ipairs(paths) do
       local normpath = vim.fs.normalize(path)
       local is_absolute = vim.startswith(normpath, "/")
-      if is_absolute and vim.fn.executable(normpath) then
+
+      if is_absolute and vim.fn.executable(normpath) == 1 then
         return normpath
       end
 
       local idx = normpath:find("/", 1, true)
       local dir, subpath
+
       if idx then
         dir = normpath:sub(1, idx - 1)
         subpath = normpath:sub(idx)
@@ -32,9 +34,11 @@ M.find_executable = function(paths, default)
         dir = normpath
         subpath = ""
       end
+
       local results = vim.fs.find(dir, { upward = true, path = ctx.dirname, limit = math.huge })
       for _, result in ipairs(results) do
         local fullpath = result .. subpath
+
         if vim.fn.executable(fullpath) == 1 then
           return fullpath
         end


### PR DESCRIPTION
If absolute path was passed, we would return it regardless if it was executable