### PR TITLE
Make formatexpr use the same option as conform.format()

### DIFF
--- a/lua/conform/init.lua
+++ b/lua/conform/init.lua
@@ -832,7 +832,7 @@ M.get_formatter_info = function(formatter, bufnr)
 end
 
 M.formatexpr = function(opts)
-  -- Change the defaults slightly from conform.format
+  -- Use the same defaults as conform.format(), but force async = false and handle the range
   opts = vim.tbl_deep_extend("keep", opts or {}, {
     bufnr = vim.api.nvim_get_current_buf(),
   })


### PR DESCRIPTION
The options for `formatexpr` is different than those used in `conform.format()`. This discrepancy causes issues when one sets up filetype-specific values for `lsp_format` or `timeout_ms`. For example, I use the following values for `formatters_by_ft`:

```lua
formatters_by_ft = {["_"] = { "trim_newlines", "trim_whitespace", lsp_format = "prefer" }}
```

I also format buffers on save.

Now when I edit a `.C` file and run `wq`, `clangd` kicks in as I set `lsp_format = "prefer"`. The file is formatted by `clangd` and saved correctly. Everything is good.

Now if I try to use `gq`, the format is performed by `trim_newlines` and `trim_whitespace`, because the default values for `lsp_format` in `formatexpr` is `fallback`. This inconsistency causes confusion when using `conform`. See also #824 #408 #752

This PR resolves this issue so that `formatexpr` will respect options used by `formatters_by_ft`.