### PR TITLE
fix(vsg): don't error if XDG_CONFIG_HOME or HOME are not defined

### DIFF
--- a/lua/conform/formatters/vsg.lua
+++ b/lua/conform/formatters/vsg.lua
@@ -14,9 +14,12 @@ local config_files = {
 }
 
 local function find_config(dirname)
+  local config_dir =
+    vim.fs.normalize(os.getenv("XDG_CONFIG_HOME") or (vim.uv.os_homedir() .. "/.config"))
+
   local paths = {
     dirname,
-    (os.getenv("XDG_CONFIG_HOME") or os.getenv("HOME") .. "/.config") .. "/vsg",
+    (config_dir .. "/vsg"),
   }
 
   for _, path in ipairs(paths) do


### PR DESCRIPTION
On Windows, `XDG_CONFIG_HOME` and `HOME` are not defined by default, which meant that the concatenation turned into `nil .. './config'` resulting in an error.

This now checks, if a home directory can be found and only then adds it to the `paths` list. Which means, that with this change, there is no option to have a global config file on Windows (Except for the user defining a `HOME` or `XDG_CONFIG_HOME` environment variable themselves).
This could be changed by adding a check to get an env-variable like `USERPROFILE` or `LOCALAPPDATA`.

Since vsg does not specify a directory for its config files and the check for one in the home directory is something conform.nvim does on its own, maybe it would be better to decide on a directory on Windows as well and add that. Let me know what you think.