### PR TITLE
cleanup: remove old autocmd for bug fixed in 0.10

### DIFF
--- a/lua/conform/init.lua
+++ b/lua/conform/init.lua
@@ -119,16 +119,6 @@ M.setup = function(opts)
         end
       end,
     })
-    vim.api.nvim_create_autocmd("VimLeavePre", {
-      desc = "conform.nvim hack to work around Neovim bug",
-      pattern = "*",
-      group = aug,
-      callback = function()
-        -- HACK: Work around https://github.com/neovim/neovim/issues/21856
-        -- causing exit code 134 on :wq
-        vim.cmd.sleep({ args = { "1m" } })
-      end,
-    })
   end
 
   if opts.format_after_save then


### PR DESCRIPTION
This has been fixed for ages - see https://github.com/neovim/neovim/issues/21856#issuecomment-2104866034. Noticed this triggering in my `:set verbose` logs.