### PR TITLE
feat(oxfmt): Include Vite config files in formatter config

### DIFF
--- a/lua/conform/formatters/oxfmt.lua
+++ b/lua/conform/formatters/oxfmt.lua
@@ -4,6 +4,9 @@ local config_file_names = {
   -- https://oxc.rs/docs/guide/usage/formatter.html#configuration-file
   ".oxfmtrc.json",
   ".oxfmtrc.jsonc",
+  -- https://viteplus.dev/guide/fmt#configuration
+   "vite.config.ts",
+  "vite.config.js"
 }
 
 ---@type conform.FileFormatterConfig


### PR DESCRIPTION
Add support for Vite configuration files in formatter, to support vite plus for instance (https://viteplus.dev/guide/fmt#configuration)