### PR TITLE
docrstfmt.lua: fix default formatter options

### DIFF
--- a/lua/conform/formatters/docstrfmt.lua
+++ b/lua/conform/formatters/docstrfmt.lua
@@ -5,5 +5,6 @@ return {
     description = "reStructuredText formatter.",
   },
   command = "docstrfmt",
+  args = { "-" },
   stdin = true,
 }


### PR DESCRIPTION
`docrstfmt` requires to specify the file name in every case, for `stdin` this is a simple  `"-"` argument.

https://github.com/LilSpazJoekp/docstrfmt/issues/199