### PR TITLE
fix(oxfmt): align root markers with official docs

### DIFF
--- a/lua/conform/formatters/oxfmt.lua
+++ b/lua/conform/formatters/oxfmt.lua
@@ -1,9 +1,10 @@
 local util = require("conform.util")
 
 local config_file_names = {
-  -- https://oxc.rs/docs/guide/usage/formatter.html#configuration-file
+  -- https://oxc.rs/docs/guide/usage/formatter/config.html#create-a-config-file
   ".oxfmtrc.json",
   ".oxfmtrc.jsonc",
+  "oxfmt.config.ts",
 }
 
 ---@type conform.FileFormatterConfig


### PR DESCRIPTION
Update oxfmt root markers according to the [docs](https://oxc.rs/docs/guide/usage/formatter/config) to include `oxfmt.config.ts`.