### PR TITLE
fix: async LSP bails on no result

### DIFF
--- a/lua/conform/lsp_format.lua
+++ b/lua/conform/lsp_format.lua
@@ -125,8 +125,8 @@ function M.format(options, callback)
         end
       request(client, method, params, function(err, result, ctx, _)
         vim.api.nvim_del_autocmd(auto_id)
-        if not result then
-          return callback(err or "No result returned from LSP formatter")
+        if err then
+          return callback(err)
         elseif not vim.api.nvim_buf_is_valid(bufnr) then
           return callback("buffer was deleted")
         elseif changedtick ~= require("conform.util").buf_get_changedtick(bufnr) then
@@ -136,6 +136,8 @@ function M.format(options, callback)
               vim.api.nvim_buf_get_name(bufnr)
             )
           )
+        elseif not result then
+          do_format(next(clients, idx))
         else
           local this_did_edit = apply_text_edits(
             result,


### PR DESCRIPTION
There was an inconsistency between the sync and async version of lsp_format:

* Sync version invokes all LSP clients even if they don't return a result, as long as they don't return an error.
* Async version stops as soon as no result is returned.

An example of this happening is when both pylsp and ruff are enabled, and pylsp only being used for refactoring and mypy, with the isort and black plugins disabled. In that case, pylsp gets tried first, returns no result, and conform doesn't even try ruff. It's fine with `format_on_save` (provided the formatting is fast enough), but `format_after_save` is unusable.

This commit fixes it by making the async/sync behaviour consistent.
