### PR TITLE
feat: add support for panache formatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,6 +332,7 @@ You can view this list in vim with `:help conform-formatters`
 - [packer_fmt](https://developer.hashicorp.com/packer/docs/commands/fmt) - The packer fmt Packer command is used to format HCL2 configuration files to a canonical format and style.
 - [palantir-java-format](https://github.com/palantir/palantir-java-format) - A modern, lambda-friendly, 120 character Java formatter.
 - [panache](https://github.com/jolars/panache) - A formatter, linter, and language server for Markdown, Quarto, and R Markdown.
+- [panache-fix](https://github.com/jolars/panache) - Linter for Markdown, Quarto, and R Markdown. Applies auto-fixable rule violations.
 - [pangu](https://github.com/vinta/pangu.py) - Insert whitespace between CJK and half-width characters.
 - [pasfmt](https://github.com/integrated-application-development/pasfmt) - Delphi code formatter.
 - [perlimports](https://github.com/perl-ide/App-perlimports) - Make implicit Perl imports explicit.

--- a/README.md
+++ b/README.md
@@ -331,6 +331,7 @@ You can view this list in vim with `:help conform-formatters`
 - [oxlint](https://github.com/oxc-project/oxc) - An oxidized replacement for ESLint that fixes lint errors.
 - [packer_fmt](https://developer.hashicorp.com/packer/docs/commands/fmt) - The packer fmt Packer command is used to format HCL2 configuration files to a canonical format and style.
 - [palantir-java-format](https://github.com/palantir/palantir-java-format) - A modern, lambda-friendly, 120 character Java formatter.
+- [panache](https://github.com/jolars/panache) - A formatter, linter, and language server for Markdown, Quarto, and R Markdown.
 - [pangu](https://github.com/vinta/pangu.py) - Insert whitespace between CJK and half-width characters.
 - [pasfmt](https://github.com/integrated-application-development/pasfmt) - Delphi code formatter.
 - [perlimports](https://github.com/perl-ide/App-perlimports) - Make implicit Perl imports explicit.

--- a/doc/conform.txt
+++ b/doc/conform.txt
@@ -472,6 +472,8 @@ FORMATTERS                                                    *conform-formatter
                        formatter.
 `panache` - A formatter, linter, and language server for Markdown, Quarto, and R
           Markdown.
+`panache-fix` - Linter for Markdown, Quarto, and R Markdown. Applies auto-
+              fixable rule violations.
 `pangu` - Insert whitespace between CJK and half-width characters.
 `pasfmt` - Delphi code formatter.
 `perlimports` - Make implicit Perl imports explicit.

--- a/doc/conform.txt
+++ b/doc/conform.txt
@@ -470,6 +470,8 @@ FORMATTERS                                                    *conform-formatter
              configuration files to a canonical format and style.
 `palantir-java-format` - A modern, lambda-friendly, 120 character Java
                        formatter.
+`panache` - A formatter, linter, and language server for Markdown, Quarto, and R
+          Markdown.
 `pangu` - Insert whitespace between CJK and half-width characters.
 `pasfmt` - Delphi code formatter.
 `perlimports` - Make implicit Perl imports explicit.

--- a/lua/conform/formatters/panache-fix.lua
+++ b/lua/conform/formatters/panache-fix.lua
@@ -1,0 +1,15 @@
+local util = require("conform.util")
+---@type conform.FileFormatterConfig
+return {
+  meta = {
+    url = "https://github.com/jolars/panache",
+    description = "Linter for Markdown, Quarto, and R Markdown. Applies auto-fixable rule violations.",
+  },
+  command = "panache",
+  args = { "--stdin-filename", "$FILENAME", "lint", "--fix" },
+  stdin = true,
+  cwd = util.root_file({
+    ".panache.toml",
+    "panache.toml",
+  }),
+}

--- a/lua/conform/formatters/panache.lua
+++ b/lua/conform/formatters/panache.lua
@@ -1,0 +1,15 @@
+local util = require("conform.util")
+---@type conform.FileFormatterConfig
+return {
+  meta = {
+    url = "https://github.com/jolars/panache",
+    description = "A formatter, linter, and language server for Markdown, Quarto, and R Markdown.",
+  },
+  command = "panache",
+  args = { "--stdin-filename", "$FILENAME", "format" },
+  stdin = true,
+  cwd = util.root_file({
+    ".panache.toml",
+    "panache.toml",
+  }),
+}


### PR DESCRIPTION
## Summary

Adds support for [Panache](https://github.com/jolars/panache), a formatter, linter, and language server for Markdown, Quarto, and R Markdown, written in Rust with a CST-based parser.

Panache understands Quarto/Pandoc-specific syntax (fenced divs, executable code blocks, attribute syntax, etc.) that other Markdown formatters often struggle with.

## Notes

- Reads from stdin and writes to stdout.
- Passes `--stdin-filename $FILENAME` so Panache can detect the flavor (Markdown vs. Quarto vs. R Markdown) from the buffer's filename.
- I've added both a formatter and `panache-fix`, which is for auto-fixing through the linter.

## Test plan

- [x] `panache` invokes correctly with `--stdin-filename <path> format` and roundtrips Markdown/Quarto/R Markdown content
- [x] `make doc` regenerates README.md / doc/conform.txt entries cleanly
- [x] `stylua --check` passes on the new formatter file